### PR TITLE
fix: add multiple events at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,17 @@ draw({
 - `type` - 각 type(grid, inverter, edge)별로 이벤트를 등록할 수 있음
 - `action` - `pixijs`의 이벤트
   - `click`, `pointerdown`, `rightclick` 등
+  - `space`로 구분하여 여러 이벤트 동시 등록 가능
 - `fn` - 이벤트에 등록할 함수, 매개변수로 `event` 전달됨
 - `eventId` - 해당 event를 쉽게 찾기 위해 Id 전달 가능함 (옵션)
 
 ```js
 event().add('grids', 'click', (e) => {
+  console.log('id: ', e.target.label);
+}, 'grid-click');
+```
+```js
+event().add('grids', 'click tap', (e) => {
   console.log('id: ', e.target.label);
 }, 'grid-click');
 ```

--- a/src/events/container.js
+++ b/src/events/container.js
@@ -40,7 +40,9 @@ export const onEvent = (viewport, eventId = '') => {
 
   const containers = findContainers(viewport, event.containerType);
   for (const container of containers) {
-    container.on(event.action, event.fn);
+    event.action.split(' ').forEach((action) => {
+      container.on(action, event.fn);
+    });
   }
 };
 
@@ -53,7 +55,9 @@ export const offEvent = (viewport, eventId = '') => {
 
   const containers = findContainers(viewport, event.containerType);
   for (const container of containers) {
-    container.off(event.action, event.fn);
+    event.action.split(' ').forEach((action) => {
+      container.off(action, event.fn);
+    });
   }
 };
 


### PR DESCRIPTION
related: #3

아래와 같이 여러 이벤트 액션을 `space`로 구분하여 등록할 수 있음
```js
event().add('grids', 'click tap', (e) => {
  console.log('id: ', e.target.label);
}, 'grid-click');
```