### PR TITLE
feat: add asset method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ It enables flexible and fast creation of 2D content.
       - [Canvas Events](#canvas-events)
       - [Double Click Handling](#double-click-handling)
       - [Multiple Actions](#multiple-actions)
+  - [asset()](#asset)
+    - [Methods](#methods-1)
+      - [add(assets)](#addassets)
+      - [load(urls, onProgress)](#loadurls-onprogress-promiseany)
+      - [get(keys)](#getkeys)
+      - [addBundle(bundleId, assets)](#addbundlebundleid-assets)
+      - [loadBundle(bundleIds, onProgress)](#loadbundlebundleids-onprogress-promiseany)
 - [🧑‍💻 Development](#-development)
   - [Setting up the development environment](#setting-up-the-development-environment)
   - [VSCode Integration](#vscode-integration)
@@ -343,6 +350,53 @@ patchMap.event().add('panelGroups', 'click pointerdown', (e) => {
   console.log('panelGroup event: ', e.target.id);
 });
 ```
+
+<br/>
+
+### `asset()`
+
+#### **Methods**
+
+##### `add(assets)`
+- Adds assets to the PixiJS Assets manager. See the [pixiJS add method](https://pixijs.download/release/docs/assets.Assets.html#add) for more information.
+- If you want to specify the icon resolution, you can add the `data: { resolution: <your_value> }` option.
+- To add an **icon asset**, make sure to prefix the `alias` with `icons-`.
+```js
+patchMap.asset().add({
+  alias: 'icons-home',
+  src: '/path/to/home.svg',
+  data: { resolution: 2 }
+})
+```
+
+
+##### `load(urls, onProgress)`: Promise\<any>
+- Loads assets from the specified URLs. Refer to the [pixiJS load method](https://pixijs.download/release/docs/assets.Assets.html#load) for more information.
+```js
+await patchMap.asset().load({
+  alias: 'icons-expand-less',
+  src: '/path/to/expand-less.svg',
+  data: { resolution: 3 }
+})
+
+patchMap.draw({
+  panelGroups: {
+    components: {
+      icon: { name: 'expand-less' }
+    }
+  }
+});
+```
+
+##### `get(keys)`
+- Retrieves assets using the specified keys. Check the [pixiJS get method](https://pixijs.download/release/docs/assets.Assets.html#get) for more information.
+
+##### `addBundle(bundleId, assets)`
+- Adds a bundle of assets to the PixiJS Assets manager. More information can be found in the [pixiJS addBundle method](https://pixijs.download/release/docs/assets.Assets.html#addBundle).
+
+##### `loadBundle(bundleIds, onProgress)`: Promise\<any>
+- Loads a bundle of assets based on the provided bundle IDs. See the [pixiJS loadBundle method](https://pixijs.download/release/docs/assets.Assets.html#loadBundle) for more information.
+
 
 <br/>
 

--- a/src/assets/utils.js
+++ b/src/assets/utils.js
@@ -1,14 +1,7 @@
 import { Assets } from 'pixi.js';
 
-export const addAsset = async (assets) => {
-  if (Array.isArray(assets)) {
-    for (const asset of assets) {
-      await addAsset(asset);
-    }
-  } else if (typeof assets === 'object') {
-    Assets.add({ data: { resolution: 3 }, ...assets });
-    await loadAsset(assets.alias);
-  }
+export const addAsset = (assets) => {
+  Assets.add(assets);
 };
 
 export const loadAsset = async (urls, onProgress) => {
@@ -19,9 +12,8 @@ export const getAsset = (keys) => {
   return Assets.get(keys);
 };
 
-export const addAssetBundle = async (bundleId, assets) => {
+export const addAssetBundle = (bundleId, assets) => {
   Assets.addBundle(bundleId, assets);
-  await loadAssetBundle(bundleId);
 };
 
 export const loadAssetBundle = async (bundleIds, onProgress) => {

--- a/src/assets/utils.js
+++ b/src/assets/utils.js
@@ -1,23 +1,31 @@
 import { Assets } from 'pixi.js';
 
-export const getAsset = (key) => {
-  return Assets.get(key);
+export const addAsset = async (assets) => {
+  if (Array.isArray(assets)) {
+    for (const asset of assets) {
+      await addAsset(asset);
+    }
+  } else if (typeof assets === 'object') {
+    Assets.add({ data: { resolution: 3 }, ...assets });
+    await loadAsset(assets.alias);
+  }
 };
 
-export const loadAsset = (key) => {
-  return Assets.load(key);
+export const loadAsset = async (urls, onProgress) => {
+  return Assets.load(urls, onProgress);
 };
 
-export const addAsset = (key, src) => {
-  Assets.add({ alias: key, src });
+export const getAsset = (keys) => {
+  return Assets.get(keys);
 };
 
-export const loadAssetBundle = (bundleId) => {
-  return Assets.loadBundle(bundleId);
-};
-
-export const addAssetBundle = (bundleId, assets) => {
+export const addAssetBundle = async (bundleId, assets) => {
   Assets.addBundle(bundleId, assets);
+  await loadAssetBundle(bundleId);
+};
+
+export const loadAssetBundle = async (bundleIds, onProgress) => {
+  return Assets.loadBundle(bundleIds, onProgress);
 };
 
 export const transformManifest = (data) => {

--- a/src/patchMap.js
+++ b/src/patchMap.js
@@ -103,9 +103,9 @@ export class PatchMap {
 
   asset() {
     return {
-      get: assets.getAsset,
       add: assets.addAsset,
       load: assets.loadAsset,
+      get: assets.getAsset,
       addBundle: assets.addAssetBundle,
       loadBundle: assets.loadAssetBundle,
     };


### PR DESCRIPTION
You can use the 'Asset' function of **pixijs** directly
If you do not want to import the 'Asset' function of **pixijs** separately, you can use the built-in 'asset' method