### PR TITLE
fix: revise element & component update logic

### DIFF
--- a/src/display/change.js
+++ b/src/display/change.js
@@ -6,34 +6,30 @@ import { selector } from '../utils/selector/selector';
 import { FONT_WEIGHT } from './components/config';
 import { parseMargin } from './utils';
 
-export const isMatch = (object, key, value) => {
-  return value == null || object.config[key] === value;
+export const changeProperty = (object, { key, value }) => {
+  if (isMatch(object, key, value)) return;
+  object[key] = value;
 };
 
 export const changeShow = (object, { show }) => {
-  if (isMatch(object, 'show', show)) return;
+  if (isConfigMatch(object, 'show', show)) return;
   object.renderable = show;
 };
 
-export const changeZIndex = (object, { zIndex }) => {
-  if (isMatch(object, 'zIndex', zIndex)) return;
-  object.zIndex = zIndex;
-};
-
 export const changeTexture = (component, { texture: textureName }) => {
-  if (isMatch(component, 'texture', textureName)) return;
+  if (isConfigMatch(component, 'texture', textureName)) return;
   const texture = getAsset(textureName);
   component.texture = texture ?? null;
 };
 
 export const changeColor = (component, { color }) => {
-  if (isMatch(component, 'color', color)) return;
+  if (isConfigMatch(component, 'color', color)) return;
   const tint = getColor(color, component.config.theme);
   component.tint = tint;
 };
 
 export const changeSize = (component, { size }) => {
-  if (isMatch(component, 'size', size)) return;
+  if (isConfigMatch(component, 'size', size)) return;
   component.setSize(size);
   changePlacement(component, {});
 };
@@ -94,9 +90,9 @@ export const changePercentSize = (
   },
 ) => {
   if (
-    isMatch(component, 'percentWidth', percentWidth) &&
-    isMatch(component, 'percentHeight', percentHeight) &&
-    isMatch(component, 'margin', margin)
+    isConfigMatch(component, 'percentWidth', percentWidth) &&
+    isConfigMatch(component, 'percentHeight', percentHeight) &&
+    isConfigMatch(component, 'margin', margin)
   ) {
     return;
   }
@@ -143,8 +139,8 @@ export const changeContent = (
   { content = component.config.content, split = component.config.split },
 ) => {
   if (
-    isMatch(component, 'content', content) &&
-    isMatch(component, 'split', split)
+    isConfigMatch(component, 'content', content) &&
+    isConfigMatch(component, 'split', split)
   ) {
     return;
   }
@@ -172,8 +168,8 @@ export const chnageTextStyle = (
   { style = component.config.style, margin = component.config.margin },
 ) => {
   if (
-    isMatch(component, 'style', style) &&
-    isMatch(component, 'margin', margin)
+    isConfigMatch(component, 'style', style) &&
+    isConfigMatch(component, 'margin', margin)
   ) {
     return;
   }
@@ -279,7 +275,10 @@ export const changeLinks = (element, { links }) => {
   }
 };
 
-export const changeAlpha = (element, { alpha }) => {
-  if (isMatch(element, 'alpha', alpha)) return;
-  element.alpha = alpha;
+export const isConfigMatch = (object, key, value) => {
+  return value == null || object.config[key] === value;
+};
+
+export const isMatch = (object, key, value) => {
+  return object[key] === value;
 };

--- a/src/display/change.js
+++ b/src/display/change.js
@@ -223,6 +223,10 @@ export const changeLineStyle = (element, { lineStyle, links }) => {
 
   path.setStrokeStyle({ ...path.strokeStyle, ...lineStyle });
   if (!links && path.links.length > 0) {
+    reRenderPath(path);
+  }
+
+  function reRenderPath(path) {
     for (const link of path.links) {
       path.moveTo(...link.sourcePoint);
       path.lineTo(...link.targetPoint);
@@ -268,7 +272,6 @@ export const changeLinks = (element, { links }) => {
     path.links.push({ sourcePoint, targetPoint });
   }
   path.stroke();
-  element.links = links;
 
   function getPoint(bounds) {
     return [bounds.x + bounds.width / 2, bounds.y + bounds.height / 2];

--- a/src/display/change.js
+++ b/src/display/change.js
@@ -278,10 +278,10 @@ export const changeLinks = (element, { links }) => {
   }
 };
 
-export const isConfigMatch = (object, key, value) => {
+const isConfigMatch = (object, key, value) => {
   return value == null || object.config[key] === value;
 };
 
-export const isMatch = (object, key, value) => {
+const isMatch = (object, key, value) => {
   return object[key] === value;
 };

--- a/src/display/components/update-components.js
+++ b/src/display/components/update-components.js
@@ -1,38 +1,35 @@
 import { isValidationError } from 'zod-validation-error';
-import { getTheme } from '../utils/get';
-import { validate } from '../utils/vaildator';
-import {
-  backgroundComponent,
-  updateBackgroundComponent,
-} from './components/background';
-import { barComponent, updateBarComponent } from './components/bar';
-import { iconComponent, updateIconComponent } from './components/icon';
-import { textComponent, updateTextComponent } from './components/text';
-import { componentSchema } from './data-schema/component-schema';
+import { getTheme } from '../../utils/get';
+import { validate } from '../../utils/vaildator';
+import { componentSchema } from '../data-schema/component-schema';
+import { backgroundComponent, updateBackgroundComponent } from './background';
+import { barComponent, updateBarComponent } from './bar';
+import { iconComponent, updateIconComponent } from './icon';
+import { textComponent, updateTextComponent } from './text';
+
+const componentFn = {
+  background: {
+    create: backgroundComponent,
+    update: updateBackgroundComponent,
+  },
+  icon: {
+    create: iconComponent,
+    update: updateIconComponent,
+  },
+  bar: {
+    create: barComponent,
+    update: updateBarComponent,
+  },
+  text: {
+    create: textComponent,
+    update: updateTextComponent,
+  },
+};
 
 export const upateComponents = (item, { components }) => {
   if (!components) return;
 
-  const componentFn = {
-    background: {
-      create: backgroundComponent,
-      update: updateBackgroundComponent,
-    },
-    icon: {
-      create: iconComponent,
-      update: updateIconComponent,
-    },
-    bar: {
-      create: barComponent,
-      update: updateBarComponent,
-    },
-    text: {
-      create: textComponent,
-      update: updateTextComponent,
-    },
-  };
   const children = [...item.children];
-
   for (let config of components) {
     const index = children.findIndex((child) =>
       matchValue('type', child, config),

--- a/src/display/data-schema/component-schema.js
+++ b/src/display/data-schema/component-schema.js
@@ -14,11 +14,11 @@ export const Placement = z.enum([
 
 export const Margin = z.string().regex(/^(\d+(\.\d+)?(\s+\d+(\.\d+)?){0,3})$/);
 
-const defaultConfig = z.object({
-  show: z.boolean().default(true),
-  label: z.nullable(z.string()).default(null),
-  zIndex: z.number().default(0),
-});
+const defaultConfig = z
+  .object({
+    show: z.boolean().default(true),
+  })
+  .passthrough();
 
 const background = defaultConfig.extend({
   type: z.literal('background'),

--- a/src/display/data-schema/component-schema.test.js
+++ b/src/display/data-schema/component-schema.test.js
@@ -93,7 +93,6 @@ describe('componentArraySchema', () => {
         expect(result.data[0].percentHeight).toBe(1);
         // show, zIndex 등 defaultConfig 값도 확인
         expect(result.data[0].show).toBe(true);
-        expect(result.data[0].zIndex).toBe(0);
       }
     });
 
@@ -139,7 +138,6 @@ describe('componentArraySchema', () => {
 
       if (result.success) {
         expect(result.data[0].show).toBe(true);
-        expect(result.data[0].zIndex).toBe(0);
       }
     });
 

--- a/src/display/data-schema/data-schema.js
+++ b/src/display/data-schema/data-schema.js
@@ -28,13 +28,13 @@ export const relation = z
   })
   .strict();
 
-const defaultInfo = z.object({
-  show: z.boolean().default(true),
-  id: z.string(),
-  label: z.nullable(z.string()).default(null),
-  zIndex: z.number().default(0),
-  metadata: z.record(z.unknown()).default({}),
-});
+const defaultInfo = z
+  .object({
+    show: z.boolean().default(true),
+    id: z.string(),
+    metadata: z.record(z.unknown()).default({}),
+  })
+  .passthrough();
 
 const gridObject = defaultInfo
   .extend({
@@ -58,7 +58,6 @@ const relationGroupObject = defaultInfo.extend({
     (val) => ({ color: 'black', ...val }),
     z.record(z.unknown()),
   ),
-  alpha: z.number().min(0).max(1).default(1),
 });
 
 const groupObject = defaultInfo.extend({

--- a/src/display/data-schema/data.d.ts
+++ b/src/display/data-schema/data.d.ts
@@ -1,87 +1,87 @@
 /**
- * 모든 객체에 공통으로 들어갈 수 있는 확장 속성용 인터페이스
+ * An interface for extended properties that can be commonly applied to all objects.
  */
 export interface BaseObject {
   [key: string]: unknown;
 }
 
 /**
- * 최상위 데이터 구조
+ * Top-level data structure
  */
 export type Data = Array<Group | Grid | Item | Relations>;
 
 /**
- * Group 타입
+ * Group Type
  */
 export interface Group extends BaseObject {
   type: 'group';
   id: string;
-  show?: boolean; // 기본값: true
-  metadata?: Record<string, unknown>; // 기본값: {}
+  show?: boolean; // default: true
+  metadata?: Record<string, unknown>; // default: {}
 
   items: Array<Group | Grid | Item | Relations>;
 }
 
 /**
- * Grid 타입
+ * Grid Type
  */
 export interface Grid extends BaseObject {
   type: 'grid';
   id: string;
-  show?: boolean; // 기본값: true
-  metadata?: Record<string, unknown>; // 기본값: {}
+  show?: boolean; // default: true
+  metadata?: Record<string, unknown>; // default: {}
 
   cells: Array<Array<0 | 1>>;
   components: components[];
 
   position?: {
-    x?: number; // 기본값: 0
-    y?: number; // 기본값: 0
+    x?: number; // default: 0
+    y?: number; // default: 0
   };
   size: {
     width: number;
     height: number;
   };
-  rotation?: number; // 기본값: 0
+  rotation?: number; // default: 0
 }
 
 /**
- * Item 타입
+ * Item Type
  */
 export interface Item extends BaseObject {
   type: 'item';
   id: string;
-  show?: boolean; // 기본값: true
-  metadata?: Record<string, unknown>; // 기본값: {}
+  show?: boolean; // default: true
+  metadata?: Record<string, unknown>; // default: {}
 
   components: components[];
 
   position?: {
-    x?: number; // 기본값: 0
-    y?: number; // 기본값: 0
+    x?: number; // default: 0
+    y?: number; // default: 0
   };
   size: {
     width: number;
     height: number;
   };
-  rotation?: number; // 기본값: 0
+  rotation?: number; // default: 0
 }
 
 /**
- * Relations 타입 (선/연결)
+ * Relations Type
  */
 export interface Relations extends BaseObject {
   type: 'relations';
   id: string;
-  show?: boolean; // 기본값: true
-  metadata?: Record<string, unknown>; // 기본값: {}
+  show?: boolean; // default: true
+  metadata?: Record<string, unknown>; // default: {}
 
   links: Array<{ source: string; target: string }>;
   lineStyle?: Record<string, unknown>;
 }
 
 /**
- * components 타입 (배경, 바, 아이콘, 텍스트)
+ * components Type (background, bar, icon, text)
  */
 export type components =
   | BackgroundComponent
@@ -94,9 +94,9 @@ export type components =
  */
 export interface BackgroundComponent extends BaseObject {
   type: 'background';
-  show?: boolean; // 기본값: true
+  show?: boolean; // default: true
   texture: string;
-  color?: string; // 기본값: '#FFFFFF'
+  color?: string; // default: '#FFFFFF'
 }
 
 /**
@@ -104,15 +104,15 @@ export interface BackgroundComponent extends BaseObject {
  */
 export interface BarComponent extends BaseObject {
   type: 'bar';
-  show?: boolean; // 기본값: true
+  show?: boolean; // default: true
   texture: string;
-  color?: string; // 기본값: 'primary.default'
-  placement?: Placement; // 기본값: 'bottom'
-  percentWidth?: number; // 기본값: 1 (0~1)
-  percentHeight?: number; // 기본값: 1 (0~1)
-  margin?: string; // 기본값: '0'
-  animation?: boolean; // 기본값: true
-  animationDuration?: number; // 기본값: 200
+  color?: string; // default: 'primary.default'
+  placement?: Placement; // default: 'bottom'
+  percentWidth?: number; // default: 1 (0~1)
+  percentHeight?: number; // default: 1 (0~1)
+  margin?: string; // default: '0'
+  animation?: boolean; // default: true
+  animationDuration?: number; // default: 200
 }
 
 /**
@@ -120,12 +120,12 @@ export interface BarComponent extends BaseObject {
  */
 export interface IconComponent extends BaseObject {
   type: 'icon';
-  show?: boolean; // 기본값: true
+  show?: boolean; // default: true
   texture: string;
-  color?: string; // 기본값: 'black'
-  size: number; // 0 이상
-  placement?: Placement; // 기본값: 'center'
-  margin?: string; // 기본값: '0'
+  color?: string; // default: 'black'
+  size: number; // 0 or higher
+  placement?: Placement; // default: 'center'
+  margin?: string; // default: '0'
 }
 
 /**
@@ -133,16 +133,16 @@ export interface IconComponent extends BaseObject {
  */
 export interface TextComponent extends BaseObject {
   type: 'text';
-  show?: boolean; // 기본값: true
-  placement?: Placement; // 기본값: 'center'
-  content?: string; // 기본값: ''
+  show?: boolean; // default: true
+  placement?: Placement; // default: 'center'
+  content?: string; // default: ''
   style?: Record<string, unknown>;
-  split?: number; // 기본값: 0
-  margin?: string; // 기본값: '0'
+  split?: number; // default: 0
+  margin?: string; // default: '0'
 }
 
 /**
- * 배치(placement)에 사용되는 문자열
+ * String used for placement
  */
 export type Placement =
   | 'left'

--- a/src/display/data-schema/data.d.ts
+++ b/src/display/data-schema/data.d.ts
@@ -1,4 +1,11 @@
 /**
+ * 모든 객체에 공통으로 들어갈 수 있는 확장 속성용 인터페이스
+ */
+export interface BaseObject {
+  [key: string]: unknown;
+}
+
+/**
  * 최상위 데이터 구조
  */
 export type Data = Array<Group | Grid | Item | Relations>;
@@ -6,12 +13,10 @@ export type Data = Array<Group | Grid | Item | Relations>;
 /**
  * Group 타입
  */
-export interface Group {
+export interface Group extends BaseObject {
   type: 'group';
   id: string;
-  label?: string | null;
   show?: boolean; // 기본값: true
-  zIndex?: number; // 기본값: 0
   metadata?: Record<string, unknown>; // 기본값: {}
 
   items: Array<Group | Grid | Item | Relations>;
@@ -20,12 +25,10 @@ export interface Group {
 /**
  * Grid 타입
  */
-export interface Grid {
+export interface Grid extends BaseObject {
   type: 'grid';
   id: string;
-  label?: string | null;
   show?: boolean; // 기본값: true
-  zIndex?: number; // 기본값: 0
   metadata?: Record<string, unknown>; // 기본값: {}
 
   cells: Array<Array<0 | 1>>;
@@ -45,12 +48,10 @@ export interface Grid {
 /**
  * Item 타입
  */
-export interface Item {
+export interface Item extends BaseObject {
   type: 'item';
   id: string;
-  label?: string | null;
   show?: boolean; // 기본값: true
-  zIndex?: number; // 기본값: 0
   metadata?: Record<string, unknown>; // 기본값: {}
 
   components: components[];
@@ -69,17 +70,14 @@ export interface Item {
 /**
  * Relations 타입 (선/연결)
  */
-export interface Relations {
+export interface Relations extends BaseObject {
   type: 'relations';
   id: string;
-  label?: string | null;
   show?: boolean; // 기본값: true
-  zIndex?: number; // 기본값: 0
   metadata?: Record<string, unknown>; // 기본값: {}
 
   links: Array<{ source: string; target: string }>;
   lineStyle?: Record<string, unknown>;
-  alpha?: number; // 기본값: 1 (0~1)
 }
 
 /**
@@ -94,12 +92,9 @@ export type components =
 /**
  * Background components
  */
-export interface BackgroundComponent {
+export interface BackgroundComponent extends BaseObject {
   type: 'background';
   show?: boolean; // 기본값: true
-  label?: string | null; // 기본값: null
-  zIndex?: number; // 기본값: 0
-
   texture: string;
   color?: string; // 기본값: '#FFFFFF'
 }
@@ -107,12 +102,9 @@ export interface BackgroundComponent {
 /**
  * Bar components
  */
-export interface BarComponent {
+export interface BarComponent extends BaseObject {
   type: 'bar';
   show?: boolean; // 기본값: true
-  label?: string | null; // 기본값: null
-  zIndex?: number; // 기본값: 0
-
   texture: string;
   color?: string; // 기본값: 'primary.default'
   placement?: Placement; // 기본값: 'bottom'
@@ -126,12 +118,9 @@ export interface BarComponent {
 /**
  * Icon components
  */
-export interface IconComponent {
+export interface IconComponent extends BaseObject {
   type: 'icon';
   show?: boolean; // 기본값: true
-  label?: string | null; // 기본값: null
-  zIndex?: number; // 기본값: 0
-
   texture: string;
   color?: string; // 기본값: 'black'
   size: number; // 0 이상
@@ -142,12 +131,9 @@ export interface IconComponent {
 /**
  * Text components
  */
-export interface TextComponent {
+export interface TextComponent extends BaseObject {
   type: 'text';
   show?: boolean; // 기본값: true
-  label?: string | null; // 기본값: null
-  zIndex?: number; // 기본값: 0
-
   placement?: Placement; // 기본값: 'center'
   content?: string; // 기본값: ''
   style?: Record<string, unknown>;

--- a/src/display/elements/group.js
+++ b/src/display/elements/group.js
@@ -1,8 +1,5 @@
-import { z } from 'zod';
-import { isValidationError } from 'zod-validation-error';
-import { deepMerge } from '../../utils/deepmerge/deepmerge';
-import { validate } from '../../utils/vaildator';
-import { changeShow, changeZIndex } from '../change';
+import { changeShow } from '../change';
+import { updateObject } from '../update-object';
 import { createContainer } from '../utils';
 
 export const createGroup = (config) => {
@@ -11,18 +8,9 @@ export const createGroup = (config) => {
   return container;
 };
 
-const updateGroupSchema = z
-  .object({
-    show: z.boolean(),
-    zIndex: z.number(),
-  })
-  .partial();
+const pipeline = [{ keys: ['show'], handler: changeShow }];
+const pipelineKeys = new Set(pipeline.flatMap((item) => item.keys));
 
-export const updateGroup = (element, opts) => {
-  const config = validate(opts, updateGroupSchema);
-  if (isValidationError(config)) throw config;
-
-  changeShow(element, config);
-  changeZIndex(element, config);
-  element.config = deepMerge(element.config, config);
+export const updateGroup = (element, options) => {
+  updateObject(element, options, pipeline, pipelineKeys);
 };

--- a/src/display/elements/relations.js
+++ b/src/display/elements/relations.js
@@ -1,16 +1,6 @@
 import { Graphics } from 'pixi.js';
-import { z } from 'zod';
-import { isValidationError } from 'zod-validation-error';
-import { deepMerge } from '../../utils/deepmerge/deepmerge';
-import { validate } from '../../utils/vaildator';
-import {
-  changeAlpha,
-  changeLineStyle,
-  changeLinks,
-  changeShow,
-  changeZIndex,
-} from '../change';
-import { relation } from '../data-schema/data-schema';
+import { changeLineStyle, changeLinks, changeShow } from '../change';
+import { updateObject } from '../update-object';
 import { createContainer } from '../utils';
 
 export const createRelations = (config) => {
@@ -21,26 +11,15 @@ export const createRelations = (config) => {
   return element;
 };
 
-const updateRelationSchema = z
-  .object({
-    show: z.boolean(),
-    zIndex: z.number(),
-    lineStyle: z.record(z.unknown()),
-    links: z.array(relation),
-    alpha: z.number(),
-  })
-  .partial();
+const pipeline = [
+  { keys: ['show'], handler: changeShow },
+  { keys: ['lineStyle'], handler: changeLineStyle },
+  { keys: ['links'], handler: changeLinks },
+];
+const pipelineKeys = new Set(pipeline.flatMap((item) => item.keys));
 
-export const updateRelations = (element, opts) => {
-  const config = validate(opts, updateRelationSchema);
-  if (isValidationError(config)) throw config;
-
-  changeShow(element, config);
-  changeZIndex(element, config);
-  changeLineStyle(element, config);
-  changeLinks(element, config);
-  changeAlpha(element, config);
-  element.config = deepMerge(element.config, config);
+export const updateRelations = (element, options) => {
+  updateObject(element, options, pipeline, pipelineKeys);
 };
 
 const createPath = () => {

--- a/src/display/update-object.js
+++ b/src/display/update-object.js
@@ -1,0 +1,25 @@
+import { deepMerge } from '../utils/deepmerge/deepmerge';
+import { changeProperty } from './change';
+
+export const updateObject = (
+  object,
+  options,
+  pipeline = [],
+  pipelineKeys = new Set([]),
+  exceptionKeys = new Set([]),
+) => {
+  if (!object) return;
+
+  for (const { keys, handler } of pipeline) {
+    const hasMatch = keys.some((key) => key in options);
+    if (hasMatch) {
+      handler(object, options);
+    }
+  }
+  for (const [key, value] of Object.entries(options)) {
+    if (!pipelineKeys.has(key) && !exceptionKeys.has(key)) {
+      changeProperty(object, { key, value });
+    }
+  }
+  object.config = deepMerge(object.config, options);
+};


### PR DESCRIPTION
The previous approach allowed changes only to predefined properties.
It has been modified to reflect all provided properties in accordance with the characteristics of the PixiJS library.
However, any properties requiring special handling will be processed separately.

It is now possible to modify various default properties such as `id`, `label`, and `alpha`.