### PR TITLE
fix: resolve animation errors on repeated draw calls

### DIFF
--- a/src/display/change/percent-size.js
+++ b/src/display/change/percent-size.js
@@ -1,7 +1,7 @@
 import gsap from 'gsap';
 import { parseMargin } from '../utils';
 import { changePlacement } from './placement';
-import { isConfigMatch, tweensOf, updateConfig } from './utils';
+import { isConfigMatch, killTweensOf, updateConfig } from './utils';
 
 export const changePercentSize = (
   object,
@@ -41,7 +41,7 @@ export const changePercentSize = (
       component.parent.size.height - (marginObj.top + marginObj.bottom);
 
     if (object.config.animation) {
-      tweensOf(component).forEach((tween) => tween.kill());
+      killTweensOf(component);
       gsap.to(component, {
         pixi: { height: maxHeight * percentHeight },
         duration: animationDuration / 1000,

--- a/src/display/change/utils.js
+++ b/src/display/change/utils.js
@@ -11,3 +11,5 @@ export const updateConfig = (object, config) => {
 };
 
 export const tweensOf = (object) => gsap.getTweensOf(object);
+
+export const killTweensOf = (object) => gsap.killTweensOf(object);

--- a/src/display/draw.js
+++ b/src/display/draw.js
@@ -1,3 +1,4 @@
+import gsap from 'gsap';
 import { createGrid } from './elements/grid';
 import { createGroup } from './elements/group';
 import { createItem } from './elements/item';
@@ -5,6 +6,7 @@ import { createRelations } from './elements/relations';
 import { update } from './update/update';
 
 export const draw = (viewport, data) => {
+  gsap.globalTimeline.clear();
   destroyChildren(viewport);
   render(viewport, data);
 


### PR DESCRIPTION
- Prevent errors caused by ongoing animations when draw is invoked multiple times
- Reset existing animations before executing a new draw