### PR TITLE
fix: add self-link for single relations and list related IDs in metadata

### DIFF
--- a/src/display/change/links.js
+++ b/src/display/change/links.js
@@ -1,4 +1,5 @@
 import { getScaleBounds } from '../../utils/canvas';
+import { deepMerge } from '../../utils/deepmerge/deepmerge';
 import { selector } from '../../utils/selector/selector';
 import { updateConfig } from './utils';
 
@@ -24,7 +25,8 @@ export const changeLinks = (object, { links }) => {
     path.links.push({ sourcePoint, targetPoint });
   }
   path.stroke();
-  updateConfig(object, { links });
+  updateConfig(object, { links }, true);
+  deepMerge(object, { metadata: { linkedIds: Object.keys(objs) } });
 
   function collectLinkedObjects(viewport, links) {
     const uniqueIds = new Set(

--- a/src/display/change/stroke-style.js
+++ b/src/display/change/stroke-style.js
@@ -9,7 +9,7 @@ export const changeStrokeStyle = (object, { strokeStyle, links }) => {
   if (!links && path.links.length > 0) {
     reRenderPath(path);
   }
-  updateConfig(object, { strokeStyle, links });
+  updateConfig(object, { strokeStyle });
 
   function reRenderPath(path) {
     path.clear();

--- a/src/display/change/utils.js
+++ b/src/display/change/utils.js
@@ -6,8 +6,8 @@ export const isConfigMatch = (object, key, value) => {
   return value == null || isSame(object.config[key], value);
 };
 
-export const updateConfig = (object, config, overWrite = false) => {
-  if (overWrite) {
+export const updateConfig = (object, config, overwrite = false) => {
+  if (overwrite) {
     object.config = { ...object.config, ...config };
   } else {
     object.config = deepMerge(object.config, config);

--- a/src/display/change/utils.js
+++ b/src/display/change/utils.js
@@ -6,8 +6,12 @@ export const isConfigMatch = (object, key, value) => {
   return value == null || isSame(object.config[key], value);
 };
 
-export const updateConfig = (object, config) => {
-  object.config = deepMerge(object.config, config);
+export const updateConfig = (object, config, overWrite = false) => {
+  if (overWrite) {
+    object.config = { ...object.config, ...config };
+  } else {
+    object.config = deepMerge(object.config, config);
+  }
 };
 
 export const tweensOf = (object) => gsap.getTweensOf(object);

--- a/src/display/utils.js
+++ b/src/display/utils.js
@@ -15,16 +15,10 @@ export const parseMargin = (margin) => {
   return { top, right, bottom, left };
 };
 
-export const createContainer = ({
-  type,
-  id,
-  label,
-  metadata,
-  isRenderGroup = false,
-}) => {
+export const createContainer = ({ type, id, label, isRenderGroup = false }) => {
   const container = new Container({ isRenderGroup });
   container.eventMode = 'static';
-  Object.assign(container, { type, id, label, metadata });
-  container.config = { type, id, label, metadata };
+  Object.assign(container, { type, id, label });
+  container.config = { type, id, label };
   return container;
 };

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -69,10 +69,18 @@ export const convertLegacyData = (data) => {
           type: 'relations',
           id: value.id,
           label: value.name,
-          links: value.children.slice(0, -1).map((child, i) => ({
-            source: child.join('.'),
-            target: value.children[i + 1].join('.'),
-          })),
+          links:
+            value.children.length > 1
+              ? value.children.slice(0, -1).map((child, i) => ({
+                  source: child.join('.'),
+                  target: value.children[i + 1].join('.'),
+                }))
+              : [
+                  {
+                    source: value.children[0].join('.'),
+                    target: value.children[0].join('.'),
+                  },
+                ],
           strokeStyle: {
             width: 4,
             color: value.properties.color.dark,


### PR DESCRIPTION
closed: #92 

- Provide the list of related object IDs in `metadata.linkedIds`
- When only one relation exists, generate a self-referential link for that relation