### PR TITLE
fix: resolve link rendering error based on Relations rendering order

### DIFF
--- a/src/patchmap.js
+++ b/src/patchmap.js
@@ -145,6 +145,7 @@ class Patchmap {
     event.removeAllEvent(this.viewport);
     this.initSelectState();
     draw(context, validatedData);
+    this.update({ path: '$..children[?(@.type=="relations")]', refresh: true });
     this.app.start();
     return validatedData;
 

--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -65,6 +65,7 @@ export const convertLegacyData = (data) => {
       }
     } else if (key === 'strings') {
       objs[key].show = false;
+      objs[key].attrs = { zIndex: 20 };
       for (const value of values) {
         objs[key].children.push({
           type: 'relations',
@@ -96,8 +97,7 @@ export const convertLegacyData = (data) => {
         });
       }
     } else {
-      objs[key].attrs = {};
-      objs[key].attrs.zIndex = 10;
+      objs[key].attrs = { zIndex: 10 };
       for (const value of values) {
         const { transform, ...props } = value.properties;
         objs[key].children.push({


### PR DESCRIPTION
This resolves an issue where links would not render correctly if the `relations` object was rendered before its link targets.







