### PR TITLE
fix: re-render Relations object using onRender

### DIFF
--- a/src/display/elements/Relations.js
+++ b/src/display/elements/Relations.js
@@ -1,6 +1,5 @@
 import { Graphics } from 'pixi.js';
 import { calcOrientedBounds } from '../../utils/bounds';
-import { selector } from '../../utils/selector/selector';
 import { relationsSchema } from '../data-schema/element-schema';
 import { Relationstyleable } from '../mixins/Relationstyleable';
 import { Linksable } from '../mixins/linksable';
@@ -14,14 +13,11 @@ export class Relations extends ComposedRelations {
   static hitScope = 'children';
 
   _renderDirty = true;
-  _renderOnNextTick = false;
 
   constructor(context) {
     super({ type: 'relations', context });
-    this.initPath();
-
-    this._updateTransform = this._updateTransform.bind(this);
-    this.context.viewport.app.ticker.add(this._updateTransform);
+    this.path = this.initPath();
+    this.onRender = this._onUpdate;
   }
 
   update(changes, options) {
@@ -33,30 +29,19 @@ export class Relations extends ComposedRelations {
     path.setStrokeStyle({ color: 'black' });
     Object.assign(path, { type: 'path', links: [] });
     this.addChild(path);
+    return path;
   }
 
-  _updateTransform() {
-    if (this._renderOnNextTick) {
-      this.renderLink();
-      this._renderOnNextTick = false;
-    }
-
+  _onUpdate() {
     if (this._renderDirty) {
-      this._renderOnNextTick = true;
-      this._renderDirty = false;
+      this.renderLink();
     }
-  }
-
-  destroy(options) {
-    this.context.viewport.app.ticker.remove(this._updateTransform);
-    super.destroy(options);
   }
 
   renderLink() {
     const { links } = this.props;
-    const path = selector(this, '$.children[?(@.type==="path")]')[0];
-    if (!path) return;
-    path.clear();
+    if (!this.path) return;
+    this.path.clear();
     let lastPoint = null;
 
     for (const link of links) {
@@ -86,11 +71,13 @@ export class Relations extends ComposedRelations {
         lastPoint[0] !== sourcePoint[0] ||
         lastPoint[1] !== sourcePoint[1]
       ) {
-        path.moveTo(...sourcePoint);
+        this.path.moveTo(...sourcePoint);
       }
-      path.lineTo(...targetPoint);
+      this.path.lineTo(...targetPoint);
       lastPoint = targetPoint;
     }
-    path.stroke();
+    this.path.stroke();
+
+    this._renderDirty = false;
   }
 }

--- a/src/display/elements/Relations.js
+++ b/src/display/elements/Relations.js
@@ -24,6 +24,11 @@ export class Relations extends ComposedRelations {
     super.update(changes, relationsSchema, options);
   }
 
+  destroy(options) {
+    this.onRender = null;
+    super.destroy(options);
+  }
+
   initPath() {
     const path = new Graphics();
     path.setStrokeStyle({ color: 'black' });

--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -6,6 +6,8 @@ import { validate } from '../../utils/validator';
 import { deepPartial } from '../../utils/zod-deep-strict-partial';
 import { Type } from './Type';
 
+const tempMatrix = new Matrix();
+
 export const Base = (superClass) => {
   return class extends Type(superClass) {
     static _handlerMap = new Map();
@@ -18,7 +20,7 @@ export const Base = (superClass) => {
       this.#context = context;
       this.props = {};
 
-      this._lastGroupTransform = new Matrix();
+      this._lastGroupTransform = tempMatrix.clone();
       this.onRender = this._onObjectUpdate;
     }
 

--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -1,3 +1,4 @@
+import { Matrix } from 'pixi.js';
 import { isValidationError } from 'zod-validation-error';
 import { deepMerge } from '../../utils/deepmerge/deepmerge';
 import { diffJson } from '../../utils/diff/diff-json';
@@ -16,10 +17,27 @@ export const Base = (superClass) => {
       super(rest);
       this.#context = context;
       this.props = {};
+
+      this._lastGroupTransform = new Matrix();
+      this.onRender = this._onObjectUpdate;
     }
 
     get context() {
       return this.#context;
+    }
+
+    _onObjectUpdate() {
+      if (!this.groupTransform || !this.visible) return;
+
+      if (!this.groupTransform.equals(this._lastGroupTransform)) {
+        this.emit('transform_updated', this);
+        this._lastGroupTransform.copyFrom(this.groupTransform);
+      }
+    }
+
+    destroy(options) {
+      this.onRender = null;
+      super.destroy(options);
     }
 
     static registerHandler(keys, handler, stage) {

--- a/src/display/mixins/linksable.js
+++ b/src/display/mixins/linksable.js
@@ -5,10 +5,26 @@ const KEYS = ['links'];
 
 export const Linksable = (superClass) => {
   const MixedClass = class extends superClass {
+    _onLinkedObjectUpdate = () => {
+      this._renderDirty = true;
+    };
+
     _applyLinks(relevantChanges) {
       const { links } = relevantChanges;
+      if (this.linkedObjects) {
+        Object.values(this.linkedObjects).forEach((obj) => {
+          if (obj) {
+            obj.off('transform_updated', this._onLinkedObjectUpdate);
+          }
+        });
+      }
+
       this.linkedObjects = uniqueLinked(this.context.viewport, links);
-      this._renderDirty = true;
+      Object.values(this.linkedObjects).forEach((obj) => {
+        if (obj) {
+          obj.on('transform_updated', this._onLinkedObjectUpdate, this);
+        }
+      });
     }
   };
   MixedClass.registerHandler(


### PR DESCRIPTION
The previous `ticker`-based update logic for `Relations` caused unnecessary re-rendering, especially during viewport panning, which led to performance degradation.

This has been improved by adopting an event-driven architecture using the `onRender` callback. Now, the `Relations` object is re-rendered only when an actual transform change occurs on a linked object, significantly reducing CPU usage and improving the stability and performance of the rendering loop.