### PR TITLE
fix: prevent unintentional deletion of label on update

### DIFF
--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -131,7 +131,7 @@ export const Base = (superClass) => {
     _applyRaw(attrs, mergeStrategy) {
       for (const [key, value] of Object.entries(attrs)) {
         if (value === undefined) {
-          if (key !== 'id' && key !== 'label') {
+          if (!['id', 'label'].includes(key)) {
             delete this[key];
           }
         } else if (key === 'x' || key === 'y') {


### PR DESCRIPTION
There was an issue where the `label` property was unintentionally deleted because it was treated as `undefined` if not included in the `changes` object when the `update` method was executed.

In the `_applyRaw` method, `label` is now handled as an exception, similar to `id`, to prevent it from being deleted. This prevents the unexpected loss of the object's `label` property.