### PR TITLE
chore: export selector utility

### DIFF
--- a/src/patch-map.ts
+++ b/src/patch-map.ts
@@ -3,4 +3,5 @@ export { UndoRedoManager } from './command/UndoRedoManager';
 export { Command } from './command/commands/base';
 export { default as Transformer } from './transformer/Transformer';
 export { default as State, PROPAGATE_EVENT } from './events/states/State';
+export { selector } from './utils/selector/selector';
 export * from './utils';


### PR DESCRIPTION
You can now import and use the `selector` utility directly from the library.