### PR TITLE
feat: add resize keep ratio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,8 @@ You can control the behavior by passing the following options when creating a `T
       - `'none'`: Does not display any outline.
   - `resizeHandles` (optional, boolean): Enables group resize handles and edge hit targets (default: `false`).
   - `resizeHistory` (optional, boolean): Determines whether resize changes are recorded in `undoRedoManager` (default: `false`). When enabled, updates in one drag gesture are grouped into a single undo/redo step.
+  - `resizeKeepRatio` (optional, boolean): Keeps the resize aspect ratio without requiring Shift (default: `false`). Shift-drag always keeps the aspect ratio regardless of this option.
+  - `getResizeKeepRatio` (optional, function): Determines whether the current resize move should keep its aspect ratio. Receives `{ event, handle, elements }` and can return `true` to keep the aspect ratio without Shift.
 
 <!-- end list -->
 
@@ -692,6 +694,7 @@ const transformer = new Transformer({
     color: '#FF00FF',
   },
   boundsDisplayMode: 'groupOnly',
+  getResizeKeepRatio: ({ event }) => event.shiftKey || isLayoutSizeLocked(),
 });
 patchmap.transformer = transformer;
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -683,6 +683,8 @@ patchmap.stateManager.setState('selection', {
       - `'none'`: 외곽선을 표시하지 않습니다.
   - `resizeHandles` (optional, boolean): 그룹 리사이즈 핸들과 엣지 히트 타깃을 활성화합니다 (기본값: `false`).
   - `resizeHistory` (optional, boolean): 리사이즈 변경 사항을 `undoRedoManager`에 기록할지 결정합니다 (기본값: `false`). 활성화하면 한 번의 드래그 제스처 내 업데이트가 하나의 실행 취소/재실행 단계로 묶입니다.
+  - `resizeKeepRatio` (optional, boolean): Shift 없이도 리사이즈 비율을 고정합니다 (기본값: `false`). Shift 드래그는 이 옵션과 관계없이 항상 비율을 고정합니다.
+  - `getResizeKeepRatio` (optional, function): 현재 리사이즈 이동에서 비율을 고정할지 결정합니다. `{ event, handle, elements }`를 받아 Shift 없이 비율을 고정하려면 `true`를 반환하면 됩니다.
 
 ```js
 import { Patchmap, Transformer } from '@conalog/patch-map';
@@ -698,6 +700,7 @@ const transformer = new Transformer({
     color: '#FF00FF',
   },
   boundsDisplayMode: 'groupOnly',
+  getResizeKeepRatio: ({ event }) => event.shiftKey || isLayoutSizeLocked(),
 });
 patchmap.transformer = transformer;
 

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -713,6 +713,106 @@ describe('Transformer', () => {
       );
     });
 
+    it('should keep aspect ratio without shift when resizeKeepRatio is true', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({
+        resizeHandles: true,
+        resizeKeepRatio: true,
+      });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+      const rectApplySpy = vi.spyOn(rect, 'apply');
+      const startOnRightEdge = transformer.toGlobal({
+        x: rect.x + rect.props.size.width,
+        y: rect.y + rect.props.size.height / 2,
+      });
+
+      resizeWithEdge(
+        patchmap,
+        transformer,
+        'right',
+        { x: 40, y: 0 },
+        startOnRightEdge,
+      );
+
+      const [rectChanges] = rectApplySpy.mock.calls.at(-1);
+      expect(rectChanges.size.width / rectChanges.size.height).toBeCloseTo(
+        100 / 80,
+        3,
+      );
+    });
+
+    it('should keep aspect ratio without shift when getResizeKeepRatio returns true', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const getResizeKeepRatio = vi.fn(() => true);
+      const transformer = new Transformer({
+        resizeHandles: true,
+        getResizeKeepRatio,
+      });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+      const rectApplySpy = vi.spyOn(rect, 'apply');
+      const startOnRightEdge = transformer.toGlobal({
+        x: rect.x + rect.props.size.width,
+        y: rect.y + rect.props.size.height / 2,
+      });
+
+      resizeWithEdge(
+        patchmap,
+        transformer,
+        'right',
+        { x: 40, y: 0 },
+        startOnRightEdge,
+      );
+
+      const [rectChanges] = rectApplySpy.mock.calls.at(-1);
+      expect(rectChanges.size.width / rectChanges.size.height).toBeCloseTo(
+        100 / 80,
+        3,
+      );
+      expect(getResizeKeepRatio).toHaveBeenCalledWith({
+        event: expect.objectContaining({ shiftKey: false }),
+        handle: 'right',
+        elements: [rect],
+      });
+    });
+
+    it('should freely resize without shift when getResizeKeepRatio returns false', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({
+        resizeHandles: true,
+        getResizeKeepRatio: () => false,
+      });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+      const rectApplySpy = vi.spyOn(rect, 'apply');
+      const startOnRightEdge = transformer.toGlobal({
+        x: rect.x + rect.props.size.width,
+        y: rect.y + rect.props.size.height / 2,
+      });
+
+      resizeWithEdge(
+        patchmap,
+        transformer,
+        'right',
+        { x: 40, y: 0 },
+        startOnRightEdge,
+      );
+
+      const [rectChanges] = rectApplySpy.mock.calls.at(-1);
+      expect(rectChanges.size.width).toBeGreaterThan(100);
+      expect(rectChanges.size.height).toBeCloseTo(80);
+    });
+
     it('should share one historyId for a single resize gesture when resizeHistory is true', () => {
       const patchmap = getPatchmap();
       patchmap.draw(resizeSampleData);
@@ -730,6 +830,38 @@ describe('Transformer', () => {
       const imageApplySpy = vi.spyOn(image, 'apply');
 
       resizeWithBottomRightHandle(patchmap, transformer, { x: 30, y: 20 });
+
+      const rectOptionsWithHistory = rectApplySpy.mock.calls
+        .map(([, options]) => options)
+        .find((options) => typeof options?.historyId === 'string');
+      const imageOptionsWithHistory = imageApplySpy.mock.calls
+        .map(([, options]) => options)
+        .find((options) => typeof options?.historyId === 'string');
+
+      expect(typeof rectOptionsWithHistory?.historyId).toBe('string');
+      expect(rectOptionsWithHistory?.historyId).toBe(
+        imageOptionsWithHistory?.historyId,
+      );
+    });
+
+    it('should share one historyId when resizeKeepRatio and resizeHistory are true', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({
+        resizeHandles: true,
+        resizeHistory: true,
+        resizeKeepRatio: true,
+      });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      const image = patchmap.selector('$..[?(@.id=="image-1")]')[0];
+      transformer.elements = [rect, image];
+
+      const rectApplySpy = vi.spyOn(rect, 'apply');
+      const imageApplySpy = vi.spyOn(image, 'apply');
+
+      resizeWithBottomRightHandle(patchmap, transformer, { x: 30, y: 0 });
 
       const rectOptionsWithHistory = rectApplySpy.mock.calls
         .map(([, options]) => options)

--- a/src/transformer/ResizeGestureController.js
+++ b/src/transformer/ResizeGestureController.js
@@ -28,6 +28,7 @@ import { normalizeBounds } from './resize-context';
  * @property {() => boolean} canStart
  * @property {() => ResizeContext | null} getResizeContext
  * @property {() => boolean} getResizeHistory
+ * @property {(context: { event: PIXI.FederatedPointerEvent, handle: string, elements: PIXI.DisplayObject[] }) => boolean} getResizeKeepRatio
  * @property {() => void} emitUpdateElements
  * @property {() => void} requestRender
  */
@@ -63,6 +64,12 @@ export default class ResizeGestureController {
 
   /**
    * @private
+   * @type {(context: { event: PIXI.FederatedPointerEvent, handle: string, elements: PIXI.DisplayObject[] }) => boolean}
+   */
+  _getResizeKeepRatio;
+
+  /**
+   * @private
    * @type {() => void}
    */
   _emitUpdateElements;
@@ -93,6 +100,7 @@ export default class ResizeGestureController {
     canStart,
     getResizeContext,
     getResizeHistory,
+    getResizeKeepRatio,
     emitUpdateElements,
     requestRender,
   }) {
@@ -100,6 +108,7 @@ export default class ResizeGestureController {
     this._canStart = canStart;
     this._getResizeContext = getResizeContext;
     this._getResizeHistory = getResizeHistory;
+    this._getResizeKeepRatio = getResizeKeepRatio;
     this._emitUpdateElements = emitUpdateElements;
     this._requestRender = requestRender;
   }
@@ -179,10 +188,21 @@ export default class ResizeGestureController {
       this._activeResize.startPoint,
       currentPoint,
     );
+    const keepRatio =
+      Boolean(event.shiftKey) ||
+      Boolean(
+        this._getResizeKeepRatio?.({
+          event,
+          handle: this._activeResize.handle,
+          elements: this._activeResize.elementStates.map(
+            (state) => state.element,
+          ),
+        }),
+      );
     const updates = computeResizeUpdates({
       activeResize: this._activeResize,
       delta,
-      keepRatio: Boolean(event.shiftKey),
+      keepRatio,
     });
 
     applyResizeUpdates({

--- a/src/transformer/Transformer.js
+++ b/src/transformer/Transformer.js
@@ -36,6 +36,8 @@ const DEFAULT_HANDLE_STYLE = { fill: '#FFFFFF', stroke: '#1099FF', size: 8 };
  * @property {BoundsDisplayMode} [boundsDisplayMode='all'] - The mode for displaying bounds.
  * @property {boolean} [resizeHandles=false] - Enable group resize handles.
  * @property {boolean} [resizeHistory=false] - Record resize changes to undo/redo history.
+ * @property {boolean} [resizeKeepRatio=false] - Keep the resize aspect ratio without requiring Shift.
+ * @property {(context: { event: PIXI.FederatedPointerEvent, handle: string, elements: PIXI.DisplayObject[] }) => boolean} [getResizeKeepRatio] - Determines whether resize should keep its aspect ratio for the current pointer move.
  */
 
 const TransformerSchema = z
@@ -45,6 +47,8 @@ const TransformerSchema = z
     boundsDisplayMode: z.enum(['all', 'groupOnly', 'elementOnly', 'none']),
     resizeHandles: z.boolean(),
     resizeHistory: z.boolean(),
+    resizeKeepRatio: z.boolean(),
+    getResizeKeepRatio: z.custom((value) => typeof value === 'function'),
   })
   .partial();
 
@@ -100,6 +104,20 @@ export default class Transformer extends Container {
    * @type {boolean}
    */
   _resizeHistory = false;
+
+  /**
+   * Flag to keep resize aspect ratio without requiring Shift.
+   * @private
+   * @type {boolean}
+   */
+  _resizeKeepRatio = false;
+
+  /**
+   * Callback to determine whether resize should keep aspect ratio.
+   * @private
+   * @type {TransformerOptions['getResizeKeepRatio'] | null}
+   */
+  _getResizeKeepRatio = null;
 
   /**
    * The container holding resize handle graphics.
@@ -166,6 +184,8 @@ export default class Transformer extends Container {
       canStart: () => this.#shouldShowResizeHandles(),
       getResizeContext: () => this.#buildResizeContext(),
       getResizeHistory: () => this._resizeHistory,
+      getResizeKeepRatio: (context) =>
+        this._resizeKeepRatio || Boolean(this._getResizeKeepRatio?.(context)),
       emitUpdateElements: () => this.#emitUpdateElements(),
       requestRender: this.update,
     });
@@ -303,6 +323,30 @@ export default class Transformer extends Container {
 
   set resizeHistory(value) {
     this._resizeHistory = Boolean(value);
+  }
+
+  /**
+   * Keeps resize aspect ratio without requiring Shift.
+   * @type {boolean}
+   */
+  get resizeKeepRatio() {
+    return this._resizeKeepRatio;
+  }
+
+  set resizeKeepRatio(value) {
+    this._resizeKeepRatio = Boolean(value);
+  }
+
+  /**
+   * Callback that determines whether resize should keep aspect ratio.
+   * @type {TransformerOptions['getResizeKeepRatio'] | null}
+   */
+  get getResizeKeepRatio() {
+    return this._getResizeKeepRatio;
+  }
+
+  set getResizeKeepRatio(value) {
+    this._getResizeKeepRatio = typeof value === 'function' ? value : null;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds Transformer resize aspect-ratio control through `resizeKeepRatio` and `getResizeKeepRatio`.
- Keeps the existing Shift-drag behavior while allowing apps to enable the same internal ratio calculation from UI state.

## Related Issue / Discussion
- Fixes #
- Refs #

## Problem / Goal
- Patch service needs the right-panel size lock toggle to keep resize aspect ratio without requiring Shift.
- This removes the need for app-level resize result correction that duplicates patch-map's existing Shift ratio logic.

## API / Behavior Changes
- Public API changes: `Transformer` now accepts `resizeKeepRatio?: boolean` and `getResizeKeepRatio?: ({ event, handle, elements }) => boolean`.
- Default value changes: none. Ratio lock still defaults to Shift-only behavior.
- Breaking changes: none.

## Migration Guide (if applicable)
- Before:
```js
const transformer = new Transformer({
  resizeHandles: true,
  resizeHistory: true,
});
```
- After:
```js
const transformer = new Transformer({
  resizeHandles: true,
  resizeHistory: true,
  getResizeKeepRatio: ({ event }) =>
    event.shiftKey || isLayoutSizeLocked(),
});
```

## Usage Example (if applicable)
```js
const transformer = new Transformer({
  resizeHandles: true,
  resizeHistory: true,
  getResizeKeepRatio: ({ event }) =>
    event.shiftKey || isLayoutSizeLocked(),
});
```

## Validation
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:headless` (if UI interaction changed)
- Manual checks performed: targeted browser Transformer test run with `npx vitest --project browser src/tests/Transformer.test.js --browser.headless`.
- Test coverage added/updated: added Transformer resize tests for `resizeKeepRatio`, callback true, callback false, and resizeHistory grouping.

## Documentation
- [x] `README.md` updated
- [x] `README_KR.md` updated
- [ ] No documentation update needed

## Release Impact
- [ ] none (internal only)
- [ ] patch (backward-compatible fix/improvement)
- [x] minor (new backward-compatible feature)

## Risks / Follow-up (Optional)
- Risks: low. The new option only changes `keepRatio` selection and reuses the existing resize math.
- Follow-up tasks: connect patch-service's size lock toggle to `getResizeKeepRatio` and remove app-level resize correction.