### PR TITLE
feat: add transformer rotation handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ Rotation is supported for these element types:
 
 Single-object selection uses an oriented selection frame that follows the selected object's rotation. Multi-object selection always uses an axis-aligned group frame. In mixed selections, rotate hit targets and the rotation center are based on the full selected group frame, while non-rotatable or locked elements remain selected and are not mutated.
 
-Holding Shift while rotating snaps the rotation delta to 15 degree increments. Elements that already use `attrs.angle` continue to write `angle`; elements that use `attrs.rotation`, or no existing rotation key, write `rotation`.
+Holding Shift while rotating snaps the rotation delta to 15 degree increments. Elements that already use `attrs.rotation` continue to write `rotation`; otherwise, rotation gestures write `angle`.
 
 <!-- end list -->
 

--- a/README.md
+++ b/README.md
@@ -674,7 +674,8 @@ You can control the behavior by passing the following options when creating a `T
       - `'elementOnly'`: Displays only the outlines of individual elements within the group.
       - `'none'`: Does not display any outline.
   - `resizeHandles` (optional, boolean): Enables group resize handles and edge hit targets (default: `false`).
-  - `resizeHistory` (optional, boolean): Determines whether resize changes are recorded in `undoRedoManager` (default: `false`). When enabled, updates in one drag gesture are grouped into a single undo/redo step.
+  - `rotateHandles` (optional, boolean): Enables invisible outside-corner rotation hit targets for rotatable selections (default: `false`).
+  - `transformHistory` (optional, boolean): Determines whether resize and rotation changes are recorded in `undoRedoManager` (default: `false`). When enabled, updates in one drag gesture are grouped into a single undo/redo step.
 
 <!-- end list -->
 
@@ -692,6 +693,9 @@ const transformer = new Transformer({
     color: '#FF00FF',
   },
   boundsDisplayMode: 'groupOnly',
+  resizeHandles: true,
+  rotateHandles: true,
+  transformHistory: true,
 });
 patchmap.transformer = transformer;
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Updates the properties of objects rendered on the canvas. By default, only the c
 - `changes` (optional, object) - New properties to apply (e.g., color, text visibility). If the `refresh` option is set to `true`, this can be omitted.
 - `history` (optional, boolean \| string) - Determines whether to record changes made by this `update` method in the `undoRedoManager`. If a string that matches the historyId of a previously saved record is provided, the two records will be merged into a single undo/redo step.
 - `relativeTransform` (optional, boolean) - Determines whether to use relative values for `position`, `rotation`, and `angle`. If `true`, the provided values will be added to the object's values.
+- `rotateOrigin` (optional, `'center'`) - When set to `'center'`, `attrs.angle` or `attrs.rotation` updates keep each object's visible center fixed by applying the required `attrs.x/y` adjustment.
 - `mergeStrategy` (optional, string) - Determines how to apply the `changes` object to the existing properties. The default is `'merge'`.
   - `'merge'` (default): Deep merges the `changes` object into the existing properties. Individual properties within objects are updated.
   - `'replace'`: Replaces the top-level properties specified in `changes` entirely. This is useful for undo operations or for completely resetting a complex property like `style` or `components` to a specific state.
@@ -679,6 +680,8 @@ You can control the behavior by passing the following options when creating a `T
 
 `resizeHistory` has been removed. Use `transformHistory` for both resize and rotation gestures.
 
+Resize handles follow a single selected object's oriented frame when that object is rotated. Multi-object resize selections continue to use an axis-aligned frame.
+
 #### Rotation handles
 
 When `rotateHandles` is enabled, the transformer creates invisible hit targets just outside the selected corners. Dragging one of those targets rotates the selected rotatable elements around the visible selection center.
@@ -686,11 +689,12 @@ When `rotateHandles` is enabled, the transformer creates invisible hit targets j
 Rotation is supported for these element types:
 
   - `Grid`
+  - `Item`
   - `Rect`
   - `Image`
   - `Text`
 
-`Item`, `Relations`, and `Group` are not rotatable through the transformer.
+`Relations` and `Group` are not rotatable through the transformer.
 
 Single-object selection uses an oriented selection frame that follows the selected object's rotation. Multi-object selection always uses an axis-aligned group frame. In mixed selections, rotate hit targets and the rotation center are based on the full selected group frame, while non-rotatable or locked elements remain selected and are not mutated.
 

--- a/README.md
+++ b/README.md
@@ -677,6 +677,25 @@ You can control the behavior by passing the following options when creating a `T
   - `rotateHandles` (optional, boolean): Enables invisible outside-corner rotation hit targets for rotatable selections (default: `false`).
   - `transformHistory` (optional, boolean): Determines whether resize and rotation changes are recorded in `undoRedoManager` (default: `false`). When enabled, updates in one drag gesture are grouped into a single undo/redo step.
 
+`resizeHistory` has been removed. Use `transformHistory` for both resize and rotation gestures.
+
+#### Rotation handles
+
+When `rotateHandles` is enabled, the transformer creates invisible hit targets just outside the selected corners. Dragging one of those targets rotates the selected rotatable elements around the visible selection center.
+
+Rotation is supported for these element types:
+
+  - `Grid`
+  - `Rect`
+  - `Image`
+  - `Text`
+
+`Item`, `Relations`, and `Group` are not rotatable through the transformer.
+
+Single-object selection uses an oriented selection frame that follows the selected object's rotation. Multi-object selection always uses an axis-aligned group frame. In mixed selections, non-rotatable or locked elements remain selected but are excluded from the rotation geometry and are not mutated.
+
+Holding Shift while rotating snaps the rotation delta to 15 degree increments. Elements that already use `attrs.angle` continue to write `angle`; elements that use `attrs.rotation`, or no existing rotation key, write `rotation`.
+
 <!-- end list -->
 
 ```js

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ Rotation is supported for these element types:
 
 `Item`, `Relations`, and `Group` are not rotatable through the transformer.
 
-Single-object selection uses an oriented selection frame that follows the selected object's rotation. Multi-object selection always uses an axis-aligned group frame. In mixed selections, non-rotatable or locked elements remain selected but are excluded from the rotation geometry and are not mutated.
+Single-object selection uses an oriented selection frame that follows the selected object's rotation. Multi-object selection always uses an axis-aligned group frame. In mixed selections, rotate hit targets and the rotation center are based on the full selected group frame, while non-rotatable or locked elements remain selected and are not mutated.
 
 Holding Shift while rotating snaps the rotation delta to 15 degree increments. Elements that already use `attrs.angle` continue to write `angle`; elements that use `attrs.rotation`, or no existing rotation key, write `rotation`.
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -706,7 +706,7 @@ patchmap.stateManager.setState('selection', {
 
 단일 객체 선택은 선택 객체의 회전을 따라가는 oriented 선택 박스를 사용합니다. 다중 객체 선택은 항상 수평 group 박스를 사용합니다. mixed selection에서는 회전 히트 타깃과 회전 중심이 선택된 전체 group frame을 기준으로 잡히고, 회전 불가 요소나 locked 요소는 선택 상태로 남지만 변경되지 않습니다.
 
-회전 중 Shift를 누르면 회전 delta가 15도 단위로 스냅됩니다. 이미 `attrs.angle`을 사용하는 요소는 계속 `angle`을 쓰고, `attrs.rotation`을 쓰거나 기존 회전 키가 없는 요소는 `rotation`을 씁니다.
+회전 중 Shift를 누르면 회전 delta가 15도 단위로 스냅됩니다. 이미 `attrs.rotation`을 사용하는 요소는 계속 `rotation`을 쓰고, 그 외에는 회전 제스처가 `angle`을 씁니다.
 
 ```js
 import { Patchmap, Transformer } from '@conalog/patch-map';

--- a/README_KR.md
+++ b/README_KR.md
@@ -685,6 +685,25 @@ patchmap.stateManager.setState('selection', {
   - `rotateHandles` (optional, boolean): 회전 가능한 선택 영역의 모서리 바깥 invisible 회전 히트 타깃을 활성화합니다 (기본값: `false`).
   - `transformHistory` (optional, boolean): 리사이즈와 회전 변경 사항을 `undoRedoManager`에 기록할지 결정합니다 (기본값: `false`). 활성화하면 한 번의 드래그 제스처 내 업데이트가 하나의 실행 취소/재실행 단계로 묶입니다.
 
+`resizeHistory`는 제거되었습니다. 리사이즈와 회전 제스처 모두 `transformHistory`를 사용하세요.
+
+#### 회전 핸들
+
+`rotateHandles`를 활성화하면 transformer는 선택 영역의 각 모서리 바깥에 보이지 않는 히트 타깃을 만듭니다. 이 타깃을 드래그하면 회전 가능한 선택 요소들이 보이는 선택 영역 중심을 기준으로 회전합니다.
+
+회전은 다음 요소 타입에서 지원됩니다.
+
+  - `Grid`
+  - `Rect`
+  - `Image`
+  - `Text`
+
+`Item`, `Relations`, `Group`은 transformer 회전 대상이 아닙니다.
+
+단일 객체 선택은 선택 객체의 회전을 따라가는 oriented 선택 박스를 사용합니다. 다중 객체 선택은 항상 수평 group 박스를 사용합니다. mixed selection에서는 회전 불가 요소나 locked 요소가 선택 상태로는 남지만, 회전 geometry에서 제외되고 변경되지 않습니다.
+
+회전 중 Shift를 누르면 회전 delta가 15도 단위로 스냅됩니다. 이미 `attrs.angle`을 사용하는 요소는 계속 `angle`을 쓰고, `attrs.rotation`을 쓰거나 기존 회전 키가 없는 요소는 `rotation`을 씁니다.
+
 ```js
 import { Patchmap, Transformer } from '@conalog/patch-map';
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -271,6 +271,7 @@ patchmap.update({
 - `changes` (optional, object) - 적용할 새로운 속성 (예: 색상, 텍스트 가시성). `refresh` 옵션을 `true`로 설정할 경우 생략할 수 있습니다.
 - `history` (optional, boolean \| string) - 해당 `update` 메소드에 의한 변경 사항을 `undoRedoManager`에 기록할 것인지 결정합니다. 이전에 저장된 기록의 historyId와 일치하는 문자열이 제공되면, 두 기록이 하나의 실행 취소/재실행 단계로 병합됩니다.
 - `relativeTransform` (optional, boolean) - `position`, `rotation`, `angle` 값에 대해서 상대값을 이용할 지 결정합니다. 만약, `true` 라면 전달된 값을 객체의 값에 더합니다.
+- `rotateOrigin` (optional, `'center'`) - `'center'`로 설정하면 `attrs.angle` 또는 `attrs.rotation` 업데이트 시 필요한 `attrs.x/y` 보정을 함께 적용해 각 객체의 보이는 중심을 유지합니다.
 - `mergeStrategy` (optional, string) - `changes` 객체를 기존 속성에 적용하는 방식을 결정합니다. 기본값은 `'merge'` 입니다.
   - `'merge'` (기본값): `changes` 객체를 기존 속성에 깊게 병합(deep merge)합니다. 객체 내의 개별 속성이 업데이트됩니다.
   - `'replace'`: `changes`에 지정된 최상위 속성을 통째로 교체합니다. `undo`를 실행하거나 `style`, `components`와 같은 복잡한 속성을 특정 상태로 완전히 리셋할 때 유용합니다.
@@ -687,6 +688,8 @@ patchmap.stateManager.setState('selection', {
 
 `resizeHistory`는 제거되었습니다. 리사이즈와 회전 제스처 모두 `transformHistory`를 사용하세요.
 
+단일 선택 객체가 회전된 상태라면 resize 핸들은 해당 객체의 oriented frame을 따라갑니다. 다중 선택 resize는 계속 axis-aligned frame을 사용합니다.
+
 #### 회전 핸들
 
 `rotateHandles`를 활성화하면 transformer는 선택 영역의 각 모서리 바깥에 보이지 않는 히트 타깃을 만듭니다. 이 타깃을 드래그하면 회전 가능한 선택 요소들이 보이는 선택 영역 중심을 기준으로 회전합니다.
@@ -694,11 +697,12 @@ patchmap.stateManager.setState('selection', {
 회전은 다음 요소 타입에서 지원됩니다.
 
   - `Grid`
+  - `Item`
   - `Rect`
   - `Image`
   - `Text`
 
-`Item`, `Relations`, `Group`은 transformer 회전 대상이 아닙니다.
+`Relations`, `Group`은 transformer 회전 대상이 아닙니다.
 
 단일 객체 선택은 선택 객체의 회전을 따라가는 oriented 선택 박스를 사용합니다. 다중 객체 선택은 항상 수평 group 박스를 사용합니다. mixed selection에서는 회전 히트 타깃과 회전 중심이 선택된 전체 group frame을 기준으로 잡히고, 회전 불가 요소나 locked 요소는 선택 상태로 남지만 변경되지 않습니다.
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -682,7 +682,8 @@ patchmap.stateManager.setState('selection', {
       - `'elementOnly'`: 그룹 내 개별 요소의 외곽선만 표시합니다.
       - `'none'`: 외곽선을 표시하지 않습니다.
   - `resizeHandles` (optional, boolean): 그룹 리사이즈 핸들과 엣지 히트 타깃을 활성화합니다 (기본값: `false`).
-  - `resizeHistory` (optional, boolean): 리사이즈 변경 사항을 `undoRedoManager`에 기록할지 결정합니다 (기본값: `false`). 활성화하면 한 번의 드래그 제스처 내 업데이트가 하나의 실행 취소/재실행 단계로 묶입니다.
+  - `rotateHandles` (optional, boolean): 회전 가능한 선택 영역의 모서리 바깥 invisible 회전 히트 타깃을 활성화합니다 (기본값: `false`).
+  - `transformHistory` (optional, boolean): 리사이즈와 회전 변경 사항을 `undoRedoManager`에 기록할지 결정합니다 (기본값: `false`). 활성화하면 한 번의 드래그 제스처 내 업데이트가 하나의 실행 취소/재실행 단계로 묶입니다.
 
 ```js
 import { Patchmap, Transformer } from '@conalog/patch-map';
@@ -698,6 +699,9 @@ const transformer = new Transformer({
     color: '#FF00FF',
   },
   boundsDisplayMode: 'groupOnly',
+  resizeHandles: true,
+  rotateHandles: true,
+  transformHistory: true,
 });
 patchmap.transformer = transformer;
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -700,7 +700,7 @@ patchmap.stateManager.setState('selection', {
 
 `Item`, `Relations`, `Group`은 transformer 회전 대상이 아닙니다.
 
-단일 객체 선택은 선택 객체의 회전을 따라가는 oriented 선택 박스를 사용합니다. 다중 객체 선택은 항상 수평 group 박스를 사용합니다. mixed selection에서는 회전 불가 요소나 locked 요소가 선택 상태로는 남지만, 회전 geometry에서 제외되고 변경되지 않습니다.
+단일 객체 선택은 선택 객체의 회전을 따라가는 oriented 선택 박스를 사용합니다. 다중 객체 선택은 항상 수평 group 박스를 사용합니다. mixed selection에서는 회전 히트 타깃과 회전 중심이 선택된 전체 group frame을 기준으로 잡히고, 회전 불가 요소나 locked 요소는 선택 상태로 남지만 변경되지 않습니다.
 
 회전 중 Shift를 누르면 회전 delta가 15도 단위로 스냅됩니다. 이미 `attrs.angle`을 사용하는 요소는 계속 `angle`을 쓰고, `attrs.rotation`을 쓰거나 기존 회전 키가 없는 요소는 `rotation`을 씁니다.
 

--- a/src/display/elements/Grid.js
+++ b/src/display/elements/Grid.js
@@ -7,6 +7,8 @@ import Element from './Element';
 const ComposedGrid = mixins(Element, Cellsable, Itemable);
 
 export class Grid extends ComposedGrid {
+  static isRotatable = true;
+
   constructor(store) {
     super({ type: 'grid', store });
   }

--- a/src/display/elements/Image.js
+++ b/src/display/elements/Image.js
@@ -10,6 +10,7 @@ const ComposedImage = mixins(Element, Sourceable, ImageSizeable);
 export class Image extends ComposedImage {
   static isSelectable = true;
   static isResizable = true;
+  static isRotatable = true;
   static hitScope = 'children';
 
   constructor(store) {

--- a/src/display/elements/Item.js
+++ b/src/display/elements/Item.js
@@ -8,6 +8,7 @@ const ComposedItem = mixins(Element, Componentsable, ItemSizeable);
 
 export class Item extends ComposedItem {
   static isSelectable = true;
+  static isRotatable = true;
   static hitScope = 'children';
 
   constructor(store) {

--- a/src/display/elements/Rect.js
+++ b/src/display/elements/Rect.js
@@ -15,6 +15,7 @@ export class Rect extends ComposedRect {
   static isElement = true;
   static isSelectable = true;
   static isResizable = true;
+  static isRotatable = true;
   static hitScope = 'self';
 
   constructor(store) {

--- a/src/display/elements/Text.js
+++ b/src/display/elements/Text.js
@@ -29,6 +29,7 @@ const ComposedText = mixins(
  */
 export class Text extends ComposedText {
   static isSelectable = true;
+  static isRotatable = true;
   static hitScope = 'children';
 
   constructor(store) {

--- a/src/display/update.js
+++ b/src/display/update.js
@@ -1,7 +1,7 @@
 import { Point } from 'pixi.js';
 import { convertArray } from '../utils/convert';
 import { selector } from '../utils/selector/selector';
-import { getCentroid, getObjectWorldCorners } from '../utils/transform';
+import { getCentroid, getObjectFrameWorldCorners } from '../utils/transform';
 import { uid } from '../utils/uuid';
 
 const DEFAULT_UPDATE_CONFIG = Object.freeze({
@@ -88,7 +88,7 @@ const applyCenterRotation = (element, attrs) => {
         : null;
   if (!rotationKey) return attrs;
 
-  const corners = getObjectWorldCorners(element);
+  const corners = getObjectFrameWorldCorners(element);
   if (corners.length === 0) return attrs;
 
   const originBefore = element.getGlobalPosition();

--- a/src/display/update.js
+++ b/src/display/update.js
@@ -1,5 +1,7 @@
+import { Point } from 'pixi.js';
 import { convertArray } from '../utils/convert';
 import { selector } from '../utils/selector/selector';
+import { getCentroid, getObjectWorldCorners } from '../utils/transform';
 import { uid } from '../utils/uuid';
 
 const DEFAULT_UPDATE_CONFIG = Object.freeze({
@@ -8,9 +10,12 @@ const DEFAULT_UPDATE_CONFIG = Object.freeze({
   changes: null,
   history: false,
   relativeTransform: false,
+  rotateOrigin: null,
   mergeStrategy: 'merge',
   refresh: false,
 });
+
+const RADIANS_PER_DEGREE = Math.PI / 180;
 
 export const update = (root, opts = {}) => {
   const config = {
@@ -22,6 +27,7 @@ export const update = (root, opts = {}) => {
     history: opts.history ?? DEFAULT_UPDATE_CONFIG.history,
     relativeTransform:
       opts.relativeTransform ?? DEFAULT_UPDATE_CONFIG.relativeTransform,
+    rotateOrigin: opts.rotateOrigin ?? DEFAULT_UPDATE_CONFIG.rotateOrigin,
     mergeStrategy: opts.mergeStrategy ?? DEFAULT_UPDATE_CONFIG.mergeStrategy,
     refresh: opts.refresh ?? DEFAULT_UPDATE_CONFIG.refresh,
   };
@@ -37,11 +43,15 @@ export const update = (root, opts = {}) => {
     if (!element) {
       continue;
     }
-    const changes = config.relativeTransform
-      ? structuredClone(baseChanges)
-      : baseChanges;
+    const changes =
+      config.relativeTransform || shouldApplyCenterRotation(config, baseChanges)
+        ? structuredClone(baseChanges)
+        : baseChanges;
     if (config.relativeTransform && changes.attrs) {
       changes.attrs = applyRelativeTransform(element, changes.attrs);
+    }
+    if (shouldApplyCenterRotation(config, changes)) {
+      changes.attrs = applyCenterRotation(element, changes.attrs);
     }
     element.apply(changes, {
       historyId,
@@ -59,6 +69,88 @@ const applyRelativeTransform = (element, changes) => {
     if (typeof changes[key] === 'number') changes[key] += element[key];
   });
   return changes;
+};
+
+const shouldApplyCenterRotation = (config, changes) =>
+  config.rotateOrigin === 'center' && hasRotationChange(changes?.attrs);
+
+const hasRotationChange = (attrs) =>
+  typeof attrs?.angle === 'number' || typeof attrs?.rotation === 'number';
+
+const applyCenterRotation = (element, attrs) => {
+  if (!element || !attrs) return attrs;
+
+  const rotationKey =
+    typeof attrs.angle === 'number'
+      ? 'angle'
+      : typeof attrs.rotation === 'number'
+        ? 'rotation'
+        : null;
+  if (!rotationKey) return attrs;
+
+  const corners = getObjectWorldCorners(element);
+  if (corners.length === 0) return attrs;
+
+  const originBefore = element.getGlobalPosition();
+  const baselineOrigin = getBaselineOrigin(element, attrs);
+  const centerBefore = getCentroid(corners);
+  const targetCenter = {
+    x: centerBefore.x + baselineOrigin.x - originBefore.x,
+    y: centerBefore.y + baselineOrigin.y - originBefore.y,
+  };
+  const centerOffset = {
+    x: centerBefore.x - originBefore.x,
+    y: centerBefore.y - originBefore.y,
+  };
+  const deltaAngle =
+    getNextRotation(attrs, rotationKey) -
+    getCurrentRotation(element, rotationKey);
+  const rotatedOffset = rotateVector(centerOffset, deltaAngle);
+  const nextOrigin = {
+    x: targetCenter.x - rotatedOffset.x,
+    y: targetCenter.y - rotatedOffset.y,
+  };
+  const localOrigin = element.parent
+    ? element.parent.toLocal(new Point(nextOrigin.x, nextOrigin.y))
+    : nextOrigin;
+
+  return {
+    ...attrs,
+    x: localOrigin.x,
+    y: localOrigin.y,
+  };
+};
+
+const getBaselineOrigin = (element, attrs) => {
+  const localOrigin = {
+    x: typeof attrs.x === 'number' ? attrs.x : element.x,
+    y: typeof attrs.y === 'number' ? attrs.y : element.y,
+  };
+
+  if (!element.parent) return localOrigin;
+  return element.parent.toGlobal(new Point(localOrigin.x, localOrigin.y));
+};
+
+const getCurrentRotation = (element, rotationKey) => {
+  if (rotationKey === 'angle') {
+    return (
+      Number(element.angle ?? element.props?.attrs?.angle ?? 0) *
+      RADIANS_PER_DEGREE
+    );
+  }
+  return Number(element.rotation ?? element.props?.attrs?.rotation ?? 0);
+};
+
+const getNextRotation = (attrs, rotationKey) =>
+  rotationKey === 'angle' ? attrs.angle * RADIANS_PER_DEGREE : attrs.rotation;
+
+const rotateVector = (vector, angle) => {
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  return {
+    x: vector.x * cos - vector.y * sin,
+    y: vector.x * sin + vector.y * cos,
+  };
 };
 
 const createHistoryId = (history) => {

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -224,6 +224,16 @@ describe('Transformer', () => {
       );
     };
 
+    const getBottomRightRotateHandle = (transformer) => {
+      const visibleHandles = getVisibleRotateHandles(transformer);
+      if (visibleHandles.length === 0)
+        throw new Error('visible rotate handle is missing');
+      const handle = visibleHandles.reduce((maxHandle, handle) =>
+        handle.x + handle.y > maxHandle.x + maxHandle.y ? handle : maxHandle,
+      );
+      return { x: handle.x, y: handle.y };
+    };
+
     const getHandleLayer = (transformer) =>
       transformer.children.find((child) => child.label === 'transform-handles');
 
@@ -920,6 +930,43 @@ describe('Transformer', () => {
 
       expect(rect.rotation).toBeCloseTo(Math.PI / 2);
       expect(item.rotation).toBe(0);
+    });
+
+    it('should position rotate targets from the full mixed selection frame', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw([
+        {
+          type: 'rect',
+          id: 'rect-rotate-frame',
+          size: { width: 100, height: 80 },
+          attrs: { x: 100, y: 100 },
+        },
+        {
+          type: 'rect',
+          id: 'locked-rect-rotate-frame',
+          size: { width: 70, height: 60 },
+          attrs: { x: 420, y: 260 },
+        },
+      ]);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-rotate-frame")]')[0];
+      const lockedRect = patchmap.selector(
+        '$..[?(@.id=="locked-rect-rotate-frame")]',
+      )[0];
+      lockedRect.apply({ locked: true });
+
+      transformer.elements = [rect];
+      transformer.draw();
+      const soloBottomRight = getBottomRightRotateHandle(transformer);
+
+      transformer.elements = [rect, lockedRect];
+      transformer.draw();
+      const mixedBottomRight = getBottomRightRotateHandle(transformer);
+
+      expect(mixedBottomRight.x).toBeGreaterThan(soloBottomRight.x);
+      expect(mixedBottomRight.y).toBeGreaterThan(soloBottomRight.y);
     });
 
     it('should snap rotation to 15 degree increments when shift is pressed', () => {

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -1033,6 +1033,62 @@ describe('Transformer', () => {
       expect(rect.rotation).toBeCloseTo(Math.PI / 12);
     });
 
+    it('should snap final rotation to 15 degree increments from a non-snapped start angle', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      rect.apply({ attrs: { angle: 4 } });
+      transformer.elements = [rect];
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        { x: 150, y: 140 },
+        (60 * Math.PI) / 180,
+        { shiftKey: true },
+      );
+
+      expect(rect.angle).toBeCloseTo(60);
+    });
+
+    it('should snap multi-selection rotation from the element angle instead of the axis-aligned frame', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw([
+        {
+          type: 'rect',
+          id: 'snap-multi-1',
+          size: { width: 100, height: 80 },
+          attrs: { x: 100, y: 100, angle: 62.27 },
+        },
+        {
+          type: 'rect',
+          id: 'snap-multi-2',
+          size: { width: 100, height: 80 },
+          attrs: { x: 260, y: 120, angle: 62.27 },
+        },
+      ]);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect1 = patchmap.selector('$..[?(@.id=="snap-multi-1")]')[0];
+      const rect2 = patchmap.selector('$..[?(@.id=="snap-multi-2")]')[0];
+      transformer.elements = [rect1, rect2];
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        { x: 150, y: 140 },
+        (15 * Math.PI) / 180,
+        { shiftKey: true },
+      );
+
+      expect(rect1.angle).toBeCloseTo(75);
+      expect(rect2.angle).toBeCloseTo(75);
+    });
+
     it('should update rotation snap when shift is pressed during a gesture', () => {
       const patchmap = getPatchmap();
       patchmap.draw(resizeSampleData);

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -858,7 +858,10 @@ describe('Transformer', () => {
       transformer.elements = [rect];
       transformer.draw();
 
-      expect(getVisibleRotateHandles(transformer)).toHaveLength(4);
+      const rotateHandles = getVisibleRotateHandles(transformer);
+      expect(rotateHandles).toHaveLength(4);
+      expect(rotateHandles[0].cursor).toContain('data:image/svg+xml');
+      expect(rotateHandles[0].cursor).not.toBe('grab');
     });
 
     it('should hide rotate targets when selection has no rotatable elements', () => {

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -909,6 +909,25 @@ describe('Transformer', () => {
       expect(rotateHandles[0].cursor).not.toBe('grab');
     });
 
+    it('should rotate cursor icons with a single selected rotated frame', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      rect.angle = 20;
+      transformer.elements = [rect];
+      transformer.draw();
+
+      const topLeftHandle = getVisibleRotateHandles(transformer).find(
+        (handle) => handle.label === 'rotate-handle:top-left',
+      );
+      expect(decodeURIComponent(topLeftHandle?.cursor ?? '')).toContain(
+        'rotate(335',
+      );
+    });
+
     it('should hide rotate targets when selection has no rotatable elements', () => {
       const patchmap = getPatchmap();
       patchmap.draw([

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -1033,6 +1033,57 @@ describe('Transformer', () => {
       expect(rect.rotation).toBeCloseTo(Math.PI / 12);
     });
 
+    it('should update rotation snap when shift is pressed during a gesture', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+      transformer.draw();
+
+      const rotateHandles = getVisibleRotateHandles(transformer);
+      const handle = rotateHandles[0];
+      const startGlobal = { x: handle.x, y: handle.y };
+      const centerGlobal = rotateHandles
+        .map((rotateHandle) => ({ x: rotateHandle.x, y: rotateHandle.y }))
+        .reduce(
+          (center, point) => ({
+            x: center.x + point.x / rotateHandles.length,
+            y: center.y + point.y / rotateHandles.length,
+          }),
+          { x: 0, y: 0 },
+        );
+      const endGlobal = rotatePoint(
+        startGlobal,
+        centerGlobal,
+        (20 * Math.PI) / 180,
+      );
+
+      handle.emit('pointerdown', {
+        global: startGlobal,
+        stopPropagation: vi.fn(),
+      });
+      patchmap.viewport.emit('pointermove', {
+        global: endGlobal,
+        shiftKey: false,
+        stopPropagation: vi.fn(),
+      });
+      expect(rect.rotation).toBeCloseTo((20 * Math.PI) / 180);
+
+      globalThis.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }));
+      expect(rect.rotation).toBeCloseTo(Math.PI / 12);
+
+      globalThis.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift' }));
+      expect(rect.rotation).toBeCloseTo((20 * Math.PI) / 180);
+
+      patchmap.viewport.emit('pointerup', {
+        global: endGlobal,
+        stopPropagation: vi.fn(),
+      });
+    });
+
     it('should share one historyId for a multi-element rotate gesture', () => {
       const patchmap = getPatchmap();
       patchmap.draw(resizeSampleData);
@@ -1177,10 +1228,10 @@ describe('Transformer', () => {
       );
 
       const [changes, options] = gridApplySpy.mock.calls.find(
-        ([callChanges]) => callChanges?.attrs?.rotation != null,
+        ([callChanges]) => callChanges?.attrs?.angle != null,
       );
       expect(Object.keys(changes)).toEqual(['attrs']);
-      expect(changes.attrs.rotation).toBeCloseTo(Math.PI / 2);
+      expect(changes.attrs.angle).toBeCloseTo(90);
       expect(typeof options?.historyId).toBe('string');
       expect(grid.children).toEqual(initialChildren);
     });

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -2,7 +2,7 @@ import { Container, Point } from 'pixi.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Transformer } from '../patch-map';
 import { setupPatchmapTests } from '../tests/render/patchmap.setup';
-import ResizeHandleLayer from '../transformer/ResizeHandleLayer';
+import TransformHandleLayer from '../transformer/TransformHandleLayer';
 
 const sampleData = [
   {
@@ -36,7 +36,9 @@ describe('Transformer', () => {
         transformer.children.some((child) => child.type === 'wireframe'),
       ).toBe(true);
       expect(
-        transformer.children.some((child) => child.label === 'resize-handles'),
+        transformer.children.some(
+          (child) => child.label === 'transform-handles',
+        ),
       ).toBe(true);
     });
 
@@ -164,6 +166,28 @@ describe('Transformer', () => {
       transformer.draw();
       expect(drawBoundsSpy).not.toHaveBeenCalled();
     });
+
+    it('should draw an oriented group frame for a single rotated element', () => {
+      patchmap.draw([
+        {
+          type: 'rect',
+          id: 'rotated-single',
+          size: { width: 100, height: 80 },
+          attrs: { x: 100, y: 100, angle: 45 },
+        },
+      ]);
+      const rect = patchmap.selector('$..[?(@.id=="rotated-single")]')[0];
+      const drawBoundsSpy = vi.spyOn(transformer.wireframe, 'drawBounds');
+      rect.angle = 45;
+      patchmap.app.render();
+
+      transformer.boundsDisplayMode = 'groupOnly';
+      transformer.elements = [rect];
+      transformer.draw();
+
+      expect(drawBoundsSpy).toHaveBeenCalledTimes(1);
+      expect(drawBoundsSpy.mock.calls[0][0].rotation).toBeCloseTo(Math.PI / 4);
+    });
   });
 
   describe('Resize Handles', () => {
@@ -201,7 +225,7 @@ describe('Transformer', () => {
     };
 
     const getHandleLayer = (transformer) =>
-      transformer.children.find((child) => child.label === 'resize-handles');
+      transformer.children.find((child) => child.label === 'transform-handles');
 
     const getVisibleHandles = (transformer) => {
       const handleLayer = getHandleLayer(transformer);
@@ -218,6 +242,16 @@ describe('Transformer', () => {
       return handleLayer
         ? handleLayer.children.filter(
             (child) => child.visible && child.label?.startsWith('resize-edge:'),
+          )
+        : [];
+    };
+
+    const getVisibleRotateHandles = (transformer) => {
+      const handleLayer = getHandleLayer(transformer);
+      return handleLayer
+        ? handleLayer.children.filter(
+            (child) =>
+              child.visible && child.label?.startsWith('rotate-handle:'),
           )
         : [];
     };
@@ -294,6 +328,56 @@ describe('Transformer', () => {
       };
 
       edgeTarget.emit('pointerdown', {
+        global: startGlobal,
+        stopPropagation: vi.fn(),
+      });
+      patchmap.viewport.emit('pointermove', {
+        global: endGlobal,
+        shiftKey,
+        stopPropagation: vi.fn(),
+      });
+      patchmap.viewport.emit('pointerup', {
+        global: endGlobal,
+        stopPropagation: vi.fn(),
+      });
+    };
+
+    const rotatePoint = (point, center, angle) => {
+      const cos = Math.cos(angle);
+      const sin = Math.sin(angle);
+      const dx = point.x - center.x;
+      const dy = point.y - center.y;
+      return {
+        x: center.x + dx * cos - dy * sin,
+        y: center.y + dx * sin + dy * cos,
+      };
+    };
+
+    const rotateWithFirstHandle = (
+      patchmap,
+      transformer,
+      _center,
+      angle,
+      { shiftKey = false } = {},
+    ) => {
+      transformer.draw();
+      const rotateHandles = getVisibleRotateHandles(transformer);
+      const handle = rotateHandles[0];
+      if (!handle) throw new Error('visible rotate handle is missing');
+
+      const startGlobal = { x: handle.x, y: handle.y };
+      const centerGlobal = rotateHandles
+        .map((rotateHandle) => ({ x: rotateHandle.x, y: rotateHandle.y }))
+        .reduce(
+          (center, point) => ({
+            x: center.x + point.x / rotateHandles.length,
+            y: center.y + point.y / rotateHandles.length,
+          }),
+          { x: 0, y: 0 },
+        );
+      const endGlobal = rotatePoint(startGlobal, centerGlobal, angle);
+
+      handle.emit('pointerdown', {
         global: startGlobal,
         stopPropagation: vi.fn(),
       });
@@ -502,7 +586,7 @@ describe('Transformer', () => {
         wireframeStyle: { color: 0 },
       });
 
-      expect(transformer._resizeHandleStyle.stroke).toBe(0);
+      expect(transformer._transformHandleStyle.stroke).toBe(0);
     });
 
     it('should render only four corner handles', () => {
@@ -564,13 +648,13 @@ describe('Transformer', () => {
         new Point(cos * x - sin * y, sin * x + cos * y);
 
       const layer = new Container({ sortableChildren: true });
-      const resizeLayer = new ResizeHandleLayer({
+      const resizeLayer = new TransformHandleLayer({
         transformer: { toLocal },
         layer,
         getViewport: () => null,
         getHandleStyle: () => ({ fill: '#fff', stroke: '#1099ff', size: 8 }),
         getStrokeWidth: () => 0,
-        onHandlePointerDown: () => {},
+        onResizePointerDown: () => {},
       });
 
       const bounds = { x: 100, y: 100, width: 100, height: 80 };
@@ -656,6 +740,26 @@ describe('Transformer', () => {
       });
     });
 
+    it('should prioritize resize corner handles over rotate hit targets', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({
+        resizeHandles: true,
+        rotateHandles: true,
+      });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+      transformer.draw();
+
+      getVisibleHandles(transformer).forEach((handle) => {
+        getVisibleRotateHandles(transformer).forEach((rotateHandle) => {
+          expect(handle.zIndex).toBeGreaterThan(rotateHandle.zIndex);
+        });
+      });
+    });
+
     it('should resize width from the right edge without changing height', () => {
       const patchmap = getPatchmap();
       patchmap.draw(resizeSampleData);
@@ -713,12 +817,12 @@ describe('Transformer', () => {
       );
     });
 
-    it('should share one historyId for a single resize gesture when resizeHistory is true', () => {
+    it('should share one historyId for a single resize gesture when transformHistory is true', () => {
       const patchmap = getPatchmap();
       patchmap.draw(resizeSampleData);
       const transformer = new Transformer({
         resizeHandles: true,
-        resizeHistory: true,
+        transformHistory: true,
       });
       patchmap.transformer = transformer;
 
@@ -742,6 +846,249 @@ describe('Transformer', () => {
       expect(rectOptionsWithHistory?.historyId).toBe(
         imageOptionsWithHistory?.historyId,
       );
+    });
+
+    it('should render invisible rotate targets for rotatable selections', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+      transformer.draw();
+
+      expect(getVisibleRotateHandles(transformer)).toHaveLength(4);
+    });
+
+    it('should hide rotate targets when selection has no rotatable elements', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const item = patchmap.selector('$..[?(@.id=="item-4")]')[0];
+      transformer.elements = [item];
+      transformer.draw();
+
+      expect(getVisibleRotateHandles(transformer)).toHaveLength(0);
+    });
+
+    it('should hide rotate targets and skip mutation for locked selections', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      rect.apply({ locked: true });
+      transformer.elements = [rect];
+      transformer.draw();
+
+      const rectApplySpy = vi.spyOn(rect, 'apply');
+      expect(getVisibleRotateHandles(transformer)).toHaveLength(0);
+      expect(() =>
+        rotateWithFirstHandle(
+          patchmap,
+          transformer,
+          { x: 150, y: 140 },
+          Math.PI / 2,
+        ),
+      ).toThrow('visible rotate handle is missing');
+      expect(rectApplySpy).not.toHaveBeenCalled();
+    });
+
+    it('should rotate only rotatable elements in a mixed selection', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      const item = patchmap.selector('$..[?(@.id=="item-4")]')[0];
+      transformer.elements = [rect, item];
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        { x: 150, y: 140 },
+        Math.PI / 2,
+      );
+
+      expect(rect.rotation).toBeCloseTo(Math.PI / 2);
+      expect(item.rotation).toBe(0);
+    });
+
+    it('should snap rotation to 15 degree increments when shift is pressed', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        { x: 150, y: 140 },
+        (20 * Math.PI) / 180,
+        { shiftKey: true },
+      );
+
+      expect(rect.rotation).toBeCloseTo(Math.PI / 12);
+    });
+
+    it('should share one historyId for a multi-element rotate gesture', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({
+        rotateHandles: true,
+        transformHistory: true,
+      });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      const image = patchmap.selector('$..[?(@.id=="image-1")]')[0];
+      transformer.elements = [rect, image];
+
+      const rectApplySpy = vi.spyOn(rect, 'apply');
+      const imageApplySpy = vi.spyOn(image, 'apply');
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        { x: 200, y: 150 },
+        Math.PI / 4,
+      );
+
+      const rectHistoryId = rectApplySpy.mock.calls.find(
+        ([, options]) => typeof options?.historyId === 'string',
+      )?.[1]?.historyId;
+      const imageHistoryId = imageApplySpy.mock.calls.find(
+        ([, options]) => typeof options?.historyId === 'string',
+      )?.[1]?.historyId;
+
+      expect(typeof rectHistoryId).toBe('string');
+      expect(rectHistoryId).toBe(imageHistoryId);
+    });
+
+    it('should start and stop mouse-edges plugin during rotation', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+      patchmap.viewport.plugin.add({ mouseEdges: {} });
+      patchmap.viewport.plugin.stop('mouse-edges');
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+
+      const startSpy = vi.spyOn(patchmap.viewport.plugin, 'start');
+      const stopSpy = vi.spyOn(patchmap.viewport.plugin, 'stop');
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        { x: 150, y: 140 },
+        Math.PI / 4,
+      );
+
+      expect(startSpy).toHaveBeenCalledWith('mouse-edges');
+      expect(stopSpy).toHaveBeenCalledWith('mouse-edges');
+    });
+
+    it('should keep positive rotate hit areas when viewport scale.x is negative', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const rect = patchmap.selector('$..[?(@.id=="rect-1")]')[0];
+      transformer.elements = [rect];
+      patchmap.viewport.scale.set(-2, 2);
+      transformer.draw();
+
+      const visibleRotateHandles = getVisibleRotateHandles(transformer);
+      expect(visibleRotateHandles.length).toBeGreaterThan(0);
+      visibleRotateHandles.forEach((handle) => {
+        expect(handle.hitArea?.width).toBeGreaterThan(0);
+        expect(handle.hitArea?.height).toBeGreaterThan(0);
+      });
+    });
+
+    it('should preserve angle attrs for text rotation', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw([
+        {
+          type: 'text',
+          id: 'text-angle',
+          text: 'LABEL',
+          attrs: { x: 100, y: 100, angle: 30 },
+          style: { fontSize: 16 },
+        },
+      ]);
+      const transformer = new Transformer({ rotateHandles: true });
+      patchmap.transformer = transformer;
+
+      const text = patchmap.selector('$..[?(@.id=="text-angle")]')[0];
+      const bounds = text.getLocalBounds();
+      transformer.elements = [text];
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        {
+          x: text.x + bounds.x + bounds.width / 2,
+          y: text.y + bounds.y + bounds.height / 2,
+        },
+        Math.PI / 2,
+      );
+
+      expect(text.props.attrs.angle).toBeCloseTo(120);
+      expect(text.props.attrs.rotation).toBeUndefined();
+    });
+
+    it('should rotate grid with attrs-only changes and keep children stable', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw([
+        {
+          type: 'grid',
+          id: 'grid-rotate',
+          cells: [[1, 1]],
+          gap: 4,
+          item: {
+            size: { width: 40, height: 40 },
+            components: [],
+          },
+          attrs: { x: 100, y: 100 },
+        },
+      ]);
+      const transformer = new Transformer({
+        rotateHandles: true,
+        transformHistory: true,
+      });
+      patchmap.transformer = transformer;
+
+      const grid = patchmap.selector('$..[?(@.id=="grid-rotate")]')[0];
+      const initialChildren = [...grid.children];
+      const gridApplySpy = vi.spyOn(grid, 'apply');
+      transformer.elements = [grid];
+
+      rotateWithFirstHandle(
+        patchmap,
+        transformer,
+        { x: 142, y: 120 },
+        Math.PI / 2,
+      );
+
+      const [changes, options] = gridApplySpy.mock.calls.find(
+        ([callChanges]) => callChanges?.attrs?.rotation != null,
+      );
+      expect(Object.keys(changes)).toEqual(['attrs']);
+      expect(changes.attrs.rotation).toBeCloseTo(Math.PI / 2);
+      expect(typeof options?.historyId).toBe('string');
+      expect(grid.children).toEqual(initialChildren);
     });
   });
 

--- a/src/tests/Transformer.test.js
+++ b/src/tests/Transformer.test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Transformer } from '../patch-map';
 import { setupPatchmapTests } from '../tests/render/patchmap.setup';
 import TransformHandleLayer from '../transformer/TransformHandleLayer';
+import { getObjectLocalCorners } from '../utils/transform';
 
 const sampleData = [
   {
@@ -650,6 +651,40 @@ describe('Transformer', () => {
       expect(getResizeFrame(transformer)).toBeTruthy();
     });
 
+    it('should align resize handles to a single rotated image frame', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw(resizeSampleData);
+      const transformer = new Transformer({ resizeHandles: true });
+      patchmap.transformer = transformer;
+
+      const image = patchmap.selector('$..[?(@.id=="image-1")]')[0];
+      image.rotation = Math.PI / 9;
+      transformer.elements = [image];
+      transformer.draw();
+
+      const visibleHandles = getVisibleHandles(transformer);
+      const corners = getObjectLocalCorners(image, patchmap.viewport);
+
+      expect(visibleHandles).toHaveLength(4);
+      corners.forEach((corner) => {
+        expect(
+          visibleHandles.some(
+            (handle) =>
+              Math.abs(handle.x - corner.x) < 0.001 &&
+              Math.abs(handle.y - corner.y) < 0.001,
+          ),
+        ).toBe(true);
+      });
+
+      const topLeftHandle = visibleHandles.find(
+        (handle) => handle.label === 'resize-handle:top-left',
+      );
+      expect(topLeftHandle?.cursor).toContain('data:image/svg+xml');
+      expect(decodeURIComponent(topLeftHandle?.cursor ?? '')).toContain(
+        'rotate(65',
+      );
+    });
+
     it('should build resize frame bounds from all transformed corners', () => {
       const angle = (105 * Math.PI) / 180;
       const cos = Math.cos(-angle);
@@ -876,12 +911,21 @@ describe('Transformer', () => {
 
     it('should hide rotate targets when selection has no rotatable elements', () => {
       const patchmap = getPatchmap();
-      patchmap.draw(resizeSampleData);
+      patchmap.draw([
+        {
+          type: 'relations',
+          id: 'relations-rotate-targets',
+          links: [],
+          style: { width: 1 },
+        },
+      ]);
       const transformer = new Transformer({ rotateHandles: true });
       patchmap.transformer = transformer;
 
-      const item = patchmap.selector('$..[?(@.id=="item-4")]')[0];
-      transformer.elements = [item];
+      const relations = patchmap.selector(
+        '$..[?(@.id=="relations-rotate-targets")]',
+      )[0];
+      transformer.elements = [relations];
       transformer.draw();
 
       expect(getVisibleRotateHandles(transformer)).toHaveLength(0);
@@ -911,7 +955,7 @@ describe('Transformer', () => {
       expect(rectApplySpy).not.toHaveBeenCalled();
     });
 
-    it('should rotate only rotatable elements in a mixed selection', () => {
+    it('should rotate rect and item elements in a mixed selection', () => {
       const patchmap = getPatchmap();
       patchmap.draw(resizeSampleData);
       const transformer = new Transformer({ rotateHandles: true });
@@ -929,7 +973,7 @@ describe('Transformer', () => {
       );
 
       expect(rect.rotation).toBeCloseTo(Math.PI / 2);
-      expect(item.rotation).toBe(0);
+      expect(item.rotation).toBeCloseTo(Math.PI / 2);
     });
 
     it('should position rotate targets from the full mixed selection frame', () => {

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -1,7 +1,7 @@
 import { Container } from 'pixi.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Transformer } from '../../patch-map';
-import { getCentroid, getObjectWorldCorners } from '../../utils/transform';
+import { getCentroid, getObjectFrameWorldCorners } from '../../utils/transform';
 import { setupPatchmapTests } from './patchmap.setup';
 
 const sampleData = [
@@ -954,7 +954,7 @@ describe('patchmap test', () => {
         },
       });
       const rect = patchmap.selector('$..[?(@.id=="center-rotate-rect")]')[0];
-      const centerBefore = getCentroid(getObjectWorldCorners(rect));
+      const centerBefore = getCentroid(getObjectFrameWorldCorners(rect));
 
       patchmap.update({
         elements: rect,
@@ -962,7 +962,7 @@ describe('patchmap test', () => {
         rotateOrigin: 'center',
       });
 
-      const centerAfter = getCentroid(getObjectWorldCorners(rect));
+      const centerAfter = getCentroid(getObjectFrameWorldCorners(rect));
       expect(centerAfter.x).toBeCloseTo(centerBefore.x);
       expect(centerAfter.y).toBeCloseTo(centerBefore.y);
       expect(rect.angle).toBe(90);

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -1,6 +1,7 @@
 import { Container } from 'pixi.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Transformer } from '../../patch-map';
+import { getCentroid, getObjectWorldCorners } from '../../utils/transform';
 import { setupPatchmapTests } from './patchmap.setup';
 
 const sampleData = [
@@ -936,6 +937,37 @@ describe('patchmap test', () => {
       const group = patchmap.selector('$..[?(@.id=="group-1")]')[0];
       expect(group.x).toBe(350);
       expect(group.y).toBe(250);
+    });
+
+    it('should keep the visible center when updating angle with rotateOrigin center', () => {
+      patchmap.update({
+        path: '$',
+        changes: {
+          children: [
+            {
+              type: 'rect',
+              id: 'center-rotate-rect',
+              size: { width: 100, height: 80 },
+              attrs: { x: 100, y: 100, angle: 0 },
+            },
+          ],
+        },
+      });
+      const rect = patchmap.selector('$..[?(@.id=="center-rotate-rect")]')[0];
+      const centerBefore = getCentroid(getObjectWorldCorners(rect));
+
+      patchmap.update({
+        elements: rect,
+        changes: { attrs: { angle: 90 } },
+        rotateOrigin: 'center',
+      });
+
+      const centerAfter = getCentroid(getObjectWorldCorners(rect));
+      expect(centerAfter.x).toBeCloseTo(centerBefore.x);
+      expect(centerAfter.y).toBeCloseTo(centerBefore.y);
+      expect(rect.angle).toBe(90);
+      expect(rect.x).toBeCloseTo(190);
+      expect(rect.y).toBeCloseTo(90);
     });
 
     it('should handle array updates with duplicate ids correctly', () => {

--- a/src/transformer/ResizeGestureController.js
+++ b/src/transformer/ResizeGestureController.js
@@ -137,6 +137,7 @@ export default class ResizeGestureController {
       handle,
       startPoint,
       bounds: normalizeBounds(resizeContext.bounds),
+      frame: resizeContext.frame,
       elementStates,
       historyId: this._getTransformHistory() ? uid() : null,
     };

--- a/src/transformer/ResizeGestureController.js
+++ b/src/transformer/ResizeGestureController.js
@@ -1,4 +1,5 @@
 import { uid } from '../utils/uuid';
+import GestureSession from './gesture-session';
 import {
   applyResizeUpdates,
   computeResizeUpdates,
@@ -27,7 +28,7 @@ import { normalizeBounds } from './resize-context';
  * @property {() => import('pixi-viewport').Viewport | null} getViewport
  * @property {() => boolean} canStart
  * @property {() => ResizeContext | null} getResizeContext
- * @property {() => boolean} getResizeHistory
+ * @property {() => boolean} getTransformHistory
  * @property {() => void} emitUpdateElements
  * @property {() => void} requestRender
  */
@@ -59,7 +60,7 @@ export default class ResizeGestureController {
    * @private
    * @type {() => boolean}
    */
-  _getResizeHistory;
+  _getTransformHistory;
 
   /**
    * @private
@@ -81,9 +82,9 @@ export default class ResizeGestureController {
 
   /**
    * @private
-   * @type {boolean}
+   * @type {GestureSession}
    */
-  _ownsMouseEdgesSession = false;
+  _session;
 
   /**
    * @param {ResizeGestureControllerOptions} options
@@ -92,16 +93,21 @@ export default class ResizeGestureController {
     getViewport,
     canStart,
     getResizeContext,
-    getResizeHistory,
+    getTransformHistory,
     emitUpdateElements,
     requestRender,
   }) {
     this._getViewport = getViewport;
     this._canStart = canStart;
     this._getResizeContext = getResizeContext;
-    this._getResizeHistory = getResizeHistory;
+    this._getTransformHistory = getTransformHistory;
     this._emitUpdateElements = emitUpdateElements;
     this._requestRender = requestRender;
+    this._session = new GestureSession({
+      getViewport,
+      onMove: this.#onMove,
+      onUp: this.#onUp,
+    });
   }
 
   /**
@@ -132,13 +138,10 @@ export default class ResizeGestureController {
       startPoint,
       bounds: normalizeBounds(resizeContext.bounds),
       elementStates,
-      historyId: this._getResizeHistory() ? uid() : null,
+      historyId: this._getTransformHistory() ? uid() : null,
     };
 
-    this.#startMouseEdges();
-    viewport.on('pointermove', this.#onMove);
-    viewport.on('pointerup', this.#onUp);
-    viewport.on('pointerupoutside', this.#onUp);
+    this._session.start();
   };
 
   /**
@@ -147,15 +150,7 @@ export default class ResizeGestureController {
    * @returns {void}
    */
   end() {
-    this.#stopMouseEdges();
-
-    const viewport = this._getViewport();
-    if (viewport) {
-      viewport.off('pointermove', this.#onMove);
-      viewport.off('pointerup', this.#onUp);
-      viewport.off('pointerupoutside', this.#onUp);
-    }
-
+    this._session.stop();
     this._activeResize = null;
   }
 
@@ -200,30 +195,4 @@ export default class ResizeGestureController {
     event.stopPropagation();
     this.end();
   };
-
-  #startMouseEdges() {
-    const viewport = this._getViewport();
-    if (!viewport?.plugin?.start || this._ownsMouseEdgesSession) return;
-
-    const mouseEdgesPlugin = viewport?.plugins?.get?.('mouse-edges');
-    if (!mouseEdgesPlugin) {
-      return;
-    }
-
-    const wasPaused = Boolean(mouseEdgesPlugin.paused);
-    if (!wasPaused) {
-      return;
-    }
-
-    viewport.plugin.start('mouse-edges');
-    this._ownsMouseEdgesSession = true;
-  }
-
-  #stopMouseEdges() {
-    if (!this._ownsMouseEdgesSession) return;
-
-    const viewport = this._getViewport();
-    viewport?.plugin?.stop?.('mouse-edges');
-    this._ownsMouseEdgesSession = false;
-  }
 }

--- a/src/transformer/RotateGestureController.js
+++ b/src/transformer/RotateGestureController.js
@@ -1,0 +1,109 @@
+import { uid } from '../utils/uuid';
+import GestureSession from './gesture-session';
+import {
+  applyRotateUpdates,
+  computeRotateUpdates,
+  createRotateElementStates,
+} from './rotate-apply';
+import { computeRotationDelta } from './rotate-utils';
+
+/**
+ * Handles pointer gesture lifecycle for rotating selected elements.
+ */
+export default class RotateGestureController {
+  _getViewport;
+  _canStart;
+  _getRotateContext;
+  _getTransformHistory;
+  _emitUpdateElements;
+  _requestRender;
+  _activeRotate = null;
+  _session;
+
+  constructor({
+    getViewport,
+    canStart,
+    getRotateContext,
+    getTransformHistory,
+    emitUpdateElements,
+    requestRender,
+  }) {
+    this._getViewport = getViewport;
+    this._canStart = canStart;
+    this._getRotateContext = getRotateContext;
+    this._getTransformHistory = getTransformHistory;
+    this._emitUpdateElements = emitUpdateElements;
+    this._requestRender = requestRender;
+    this._session = new GestureSession({
+      getViewport,
+      onMove: this.#onMove,
+      onUp: this.#onUp,
+    });
+  }
+
+  begin = (_handle, event) => {
+    const viewport = this._getViewport();
+    if (!this._canStart() || !viewport) return;
+
+    event.stopPropagation();
+    this.end();
+
+    const rotateContext = this._getRotateContext();
+    if (!rotateContext) return;
+
+    this._activeRotate = {
+      startPoint: viewport.toWorld(event.global),
+      frame: rotateContext.frame,
+      elementStates: createRotateElementStates({
+        elements: rotateContext.elements,
+        viewport,
+      }),
+      historyId: this._getTransformHistory() ? uid() : null,
+    };
+
+    this._session.start();
+  };
+
+  end() {
+    this._session.stop();
+    this._activeRotate = null;
+  }
+
+  destroy() {
+    this.end();
+  }
+
+  #onMove = (event) => {
+    const viewport = this._getViewport();
+    if (!this._activeRotate || !viewport) return;
+
+    event.stopPropagation();
+
+    const currentPoint = viewport.toWorld(event.global);
+    const deltaAngle = computeRotationDelta({
+      center: this._activeRotate.frame.center,
+      startPoint: this._activeRotate.startPoint,
+      currentPoint,
+      snap: Boolean(event.shiftKey),
+    });
+    const updates = computeRotateUpdates({
+      activeRotate: this._activeRotate,
+      deltaAngle,
+    });
+
+    applyRotateUpdates({
+      updates,
+      viewport,
+      historyId: this._activeRotate.historyId,
+    });
+
+    this._emitUpdateElements();
+    this._requestRender();
+  };
+
+  #onUp = (event) => {
+    if (!this._activeRotate) return;
+    event.stopPropagation();
+    this.end();
+  };
+}

--- a/src/transformer/RotateGestureController.js
+++ b/src/transformer/RotateGestureController.js
@@ -52,14 +52,18 @@ export default class RotateGestureController {
     const rotateContext = this._getRotateContext();
     if (!rotateContext) return;
 
+    const elementStates = createRotateElementStates({
+      elements: rotateContext.elements,
+      viewport,
+    });
+
     this._activeRotate = {
       startPoint: viewport.toWorld(event.global),
       currentPoint: viewport.toWorld(event.global),
       frame: rotateContext.frame,
-      elementStates: createRotateElementStates({
-        elements: rotateContext.elements,
-        viewport,
-      }),
+      snapBaseAngle:
+        elementStates[0]?.rotation ?? rotateContext.frame.rotation ?? 0,
+      elementStates,
       historyId: this._getTransformHistory() ? uid() : null,
     };
     this._isShiftPressed = Boolean(event.shiftKey);
@@ -102,6 +106,7 @@ export default class RotateGestureController {
       startPoint: this._activeRotate.startPoint,
       currentPoint,
       snap,
+      snapBaseAngle: this._activeRotate.snapBaseAngle,
     });
     const updates = computeRotateUpdates({
       activeRotate: this._activeRotate,

--- a/src/transformer/RotateGestureController.js
+++ b/src/transformer/RotateGestureController.js
@@ -18,6 +18,7 @@ export default class RotateGestureController {
   _emitUpdateElements;
   _requestRender;
   _activeRotate = null;
+  _isShiftPressed = false;
   _session;
 
   constructor({
@@ -53,6 +54,7 @@ export default class RotateGestureController {
 
     this._activeRotate = {
       startPoint: viewport.toWorld(event.global),
+      currentPoint: viewport.toWorld(event.global),
       frame: rotateContext.frame,
       elementStates: createRotateElementStates({
         elements: rotateContext.elements,
@@ -60,13 +62,17 @@ export default class RotateGestureController {
       }),
       historyId: this._getTransformHistory() ? uid() : null,
     };
+    this._isShiftPressed = Boolean(event.shiftKey);
 
     this._session.start();
+    this.#startKeyboardTracking();
   };
 
   end() {
     this._session.stop();
+    this.#stopKeyboardTracking();
     this._activeRotate = null;
+    this._isShiftPressed = false;
   }
 
   destroy() {
@@ -80,11 +86,22 @@ export default class RotateGestureController {
     event.stopPropagation();
 
     const currentPoint = viewport.toWorld(event.global);
+    this._activeRotate.currentPoint = currentPoint;
+    if (Object.hasOwn(event, 'shiftKey')) {
+      this._isShiftPressed = Boolean(event.shiftKey);
+    }
+    this.#applyRotation(currentPoint, this._isShiftPressed);
+  };
+
+  #applyRotation(currentPoint, snap) {
+    const viewport = this._getViewport();
+    if (!this._activeRotate || !viewport || !currentPoint) return;
+
     const deltaAngle = computeRotationDelta({
       center: this._activeRotate.frame.center,
       startPoint: this._activeRotate.startPoint,
       currentPoint,
-      snap: Boolean(event.shiftKey),
+      snap,
     });
     const updates = computeRotateUpdates({
       activeRotate: this._activeRotate,
@@ -99,11 +116,33 @@ export default class RotateGestureController {
 
     this._emitUpdateElements();
     this._requestRender();
-  };
+  }
 
   #onUp = (event) => {
     if (!this._activeRotate) return;
     event.stopPropagation();
     this.end();
   };
+
+  #onKeyDown = (event) => {
+    if (event.key !== 'Shift' || this._isShiftPressed) return;
+    this._isShiftPressed = true;
+    this.#applyRotation(this._activeRotate?.currentPoint, true);
+  };
+
+  #onKeyUp = (event) => {
+    if (event.key !== 'Shift' || !this._isShiftPressed) return;
+    this._isShiftPressed = false;
+    this.#applyRotation(this._activeRotate?.currentPoint, false);
+  };
+
+  #startKeyboardTracking() {
+    globalThis.addEventListener?.('keydown', this.#onKeyDown);
+    globalThis.addEventListener?.('keyup', this.#onKeyUp);
+  }
+
+  #stopKeyboardTracking() {
+    globalThis.removeEventListener?.('keydown', this.#onKeyDown);
+    globalThis.removeEventListener?.('keyup', this.#onKeyUp);
+  }
 }

--- a/src/transformer/TransformHandleLayer.js
+++ b/src/transformer/TransformHandleLayer.js
@@ -49,6 +49,7 @@ const createResizeCursor = (degrees) => {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 -960 960 960"><g transform="rotate(${degrees} 480 -480)"><path d="${path}" fill="black" stroke="white" stroke-width="70" stroke-linejoin="round" paint-order="stroke fill"/></g></svg>`;
   return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 12 12, ${getResizeCursorFallback(degrees)}`;
 };
+const resizeCursorCache = new Map();
 
 const createRotateCursor = (degrees) => {
   const rotation = degrees + 35;
@@ -226,7 +227,9 @@ export default class TransformHandleLayer {
 
     this.#ensureHandles();
     this.#ensureEdges();
-    this.#ensureRotateTargets();
+    if (rotateFrame) {
+      this.#ensureRotateTargets();
+    }
     this.#ensureResizeFrame();
 
     const viewport = this._getViewport();
@@ -656,7 +659,13 @@ const getResizeCursors = (frame) => {
 
 const getResizeCursorForAngle = (angle) => {
   const normalized = ((angle % 180) + 180) % 180;
-  return createResizeCursor(normalized);
+  const key = Math.round(normalized * 1000) / 1000;
+  let cursor = resizeCursorCache.get(key);
+  if (!cursor) {
+    cursor = createResizeCursor(key);
+    resizeCursorCache.set(key, cursor);
+  }
+  return cursor;
 };
 
 const getResizeCursorFallback = (angle) => {

--- a/src/transformer/TransformHandleLayer.js
+++ b/src/transformer/TransformHandleLayer.js
@@ -43,6 +43,13 @@ const RESIZE_CURSOR_ANGLES = {
   'top-right': 315,
 };
 
+const ROTATE_CURSOR_ANGLES = {
+  'top-left': -45,
+  'top-right': 45,
+  'bottom-right': 135,
+  'bottom-left': -135,
+};
+
 const createResizeCursor = (degrees) => {
   const path =
     'm233-440 75 75q11 12 11.5 28.5T308-308q-12 12-28 12t-28-12L108-452q-6-6-8.5-13T97-480q0-8 2.5-15t8.5-13l144-144q12-12 28-12t28 12q12 12 12 28.5T308-595l-75 75h494l-75-75q-11-12-11.5-28.5T652-652q12-12 28-12t28 12l144 144q6 6 8.5 13t2.5 15q0 8-2.5 15t-8.5 13L708-308q-12 12-28 12t-28-12q-12-12-12-28.5t12-28.5l75-75H233Z';
@@ -50,20 +57,14 @@ const createResizeCursor = (degrees) => {
   return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 12 12, ${getResizeCursorFallback(degrees)}`;
 };
 const resizeCursorCache = new Map();
+const rotateCursorCache = new Map();
 
 const createRotateCursor = (degrees) => {
-  const rotation = degrees + 35;
+  const rotation = normalizeCursorAngle(degrees);
   const path =
-    'M482-160q-134 0-228-93t-94-227v-7l-36 36q-11 11-28 11t-28-11q-11-11-11-28t11-28l104-104q12-12 28-12t28 12l104 104q11 11 11 28t-11 28q-11 11-28 11t-28-11l-36-36v7q0 100 70.5 170T482-240q16 0 31.5-2t30.5-7q17-5 32 1t23 21q8 16 1.5 31.5T577-175q-23 8-47 11.5t-48 3.5Zm-4-560q-16 0-31.5 2t-30.5 7q-17 5-32.5-1T360-733q-8-15-1.5-30.5T381-784q24-8 48-12t49-4q134 0 228 93t94 227v7l36-36q11-11 28-11t28 11q11 11 11 28t-11 28L788-349q-12 12-28 12t-28-12L628-453q-11-11-11-28t11-28q11-11 28-11t28 11l36 36v-7q0-100-70.5-170T478-720Z';
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 -960 960 960"><g transform="rotate(${rotation} 480 -480)"><path d="${path}" fill="black" stroke="white" stroke-width="70" paint-order="stroke fill"/></g></svg>`;
+    'M18.293 0C18.5763 1.23861e-08 18.8142 0.0954427 19.0059 0.287109C19.1975 0.478765 19.293 0.716697 19.293 1V6C19.2929 6.28307 19.1972 6.52035 19.0059 6.71191C18.8142 6.90358 18.5763 7 18.293 7H13.293C13.0096 7 12.7717 6.90358 12.5801 6.71191C12.3887 6.52035 12.293 6.28307 12.293 6C12.293 5.7167 12.3885 5.47877 12.5801 5.28711C12.7717 5.09544 13.0096 5 13.293 5H15.9932C15.1432 4.05006 14.1474 3.3121 13.0059 2.78711C11.9403 2.29712 10.8199 2.03854 9.64551 2.00586C8.4717 2.03871 7.35213 2.29738 6.28711 2.78711C5.14547 3.3121 4.14979 4.05004 3.2998 5H6C6.28303 5.00011 6.52039 5.09567 6.71191 5.28711C6.90358 5.47878 7 5.71667 7 6C6.99997 6.28319 6.90343 6.52031 6.71191 6.71191C6.52036 6.90347 6.28312 6.99989 6 7H1C0.716667 7 0.478776 6.90358 0.287109 6.71191C0.0955925 6.52031 2.75366e-05 6.28319 0 6V1C-1.23849e-08 0.716667 0.0954427 0.478776 0.287109 0.287109C0.478744 0.0955647 0.716757 1.2381e-08 1 0C1.28303 0.000110013 1.52039 0.0956748 1.71191 0.287109C1.90358 0.478776 2 0.716667 2 1V2.91016C2.61573 2.33291 3.30071 1.82863 4.05566 1.39941C5.69712 0.466276 7.4762 6.32214e-05 9.39258 0C9.47703 3.69138e-09 9.56155 0.00399917 9.64551 0.00585938C9.72992 0.0039782 9.81451 7.28876e-07 9.89941 0C11.8161 -8.37802e-08 13.5956 0.466081 15.2373 1.39941C15.9924 1.82868 16.6772 2.33281 17.293 2.91016V1C17.293 0.716697 17.3885 0.478765 17.5801 0.287109C17.7717 0.0954427 18.0096 -1.23849e-08 18.293 0Z';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="-5 -9 30 30"><g transform="translate(10 3.5) rotate(${rotation}) translate(-10 -3.5)"><path d="${path}" fill="black" stroke="white" stroke-width="1.8" stroke-linejoin="round" paint-order="stroke fill"/></g></svg>`;
   return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 12 12, crosshair`;
-};
-
-const ROTATE_CURSORS = {
-  'top-left': createRotateCursor(-45),
-  'top-right': createRotateCursor(45),
-  'bottom-right': createRotateCursor(135),
-  'bottom-left': createRotateCursor(-135),
 };
 
 const CORNER_RESIZE_HANDLES = [
@@ -362,7 +363,7 @@ export default class TransformHandleLayer {
       graphic.eventMode = 'static';
       graphic.zIndex = ROTATE_TARGET_Z_INDEX;
       graphic.label = `rotate-handle:${handle}`;
-      graphic.cursor = ROTATE_CURSORS[handle] ?? 'crosshair';
+      graphic.cursor = getRotateCursorForAngle(ROTATE_CURSOR_ANGLES[handle]);
       graphic.on('pointerdown', (event) =>
         this._onRotatePointerDown(handle, event),
       );
@@ -540,6 +541,7 @@ export default class TransformHandleLayer {
     const halfHitSize = hitSize / 2;
     const offset = ROTATE_HIT_OFFSET / viewportScale;
     const positions = getCornerMap(frame.corners);
+    const cursors = getRotateCursors(frame);
 
     this._rotateMap.forEach((target, key) => {
       const corner = positions[key];
@@ -573,6 +575,7 @@ export default class TransformHandleLayer {
         alpha: 0.001,
       });
       target.position.set(localPosition.x, localPosition.y);
+      target.cursor = cursors[key] ?? 'crosshair';
       target.visible = true;
     });
   }
@@ -666,6 +669,35 @@ const getResizeCursorForAngle = (angle) => {
     resizeCursorCache.set(key, cursor);
   }
   return cursor;
+};
+
+const getRotateCursors = (frame) => {
+  const rotationDegrees = frame?.rotation
+    ? (frame.rotation * 180) / Math.PI
+    : 0;
+
+  return Object.fromEntries(
+    Object.entries(ROTATE_CURSOR_ANGLES).map(([handle, angle]) => [
+      handle,
+      getRotateCursorForAngle(angle + rotationDegrees),
+    ]),
+  );
+};
+
+const getRotateCursorForAngle = (angle) => {
+  const key = normalizeCursorAngle(angle);
+  let cursor = rotateCursorCache.get(key);
+  if (!cursor) {
+    cursor = createRotateCursor(key);
+    rotateCursorCache.set(key, cursor);
+  }
+  return cursor;
+};
+
+const normalizeCursorAngle = (angle) => {
+  const normalized = ((angle % 360) + 360) % 360;
+  const rounded = Math.round(normalized * 1000) / 1000;
+  return rounded === 360 ? 0 : rounded;
 };
 
 const getResizeCursorFallback = (angle) => {

--- a/src/transformer/TransformHandleLayer.js
+++ b/src/transformer/TransformHandleLayer.js
@@ -32,6 +32,24 @@ const RESIZE_CURSORS = {
   left: 'ew-resize',
 };
 
+const RESIZE_CURSOR_ANGLES = {
+  right: 0,
+  'bottom-right': 45,
+  bottom: 90,
+  'bottom-left': 135,
+  left: 180,
+  'top-left': 225,
+  top: 270,
+  'top-right': 315,
+};
+
+const createResizeCursor = (degrees) => {
+  const path =
+    'm233-440 75 75q11 12 11.5 28.5T308-308q-12 12-28 12t-28-12L108-452q-6-6-8.5-13T97-480q0-8 2.5-15t8.5-13l144-144q12-12 28-12t28 12q12 12 12 28.5T308-595l-75 75h494l-75-75q-11-12-11.5-28.5T652-652q12-12 28-12t28 12l144 144q6 6 8.5 13t2.5 15q0 8-2.5 15t-8.5 13L708-308q-12 12-28 12t-28-12q-12-12-12-28.5t12-28.5l75-75H233Z';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 -960 960 960"><g transform="rotate(${degrees} 480 -480)"><path d="${path}" fill="black" stroke="white" stroke-width="70" stroke-linejoin="round" paint-order="stroke fill"/></g></svg>`;
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 12 12, ${getResizeCursorFallback(degrees)}`;
+};
+
 const createRotateCursor = (degrees) => {
   const rotation = degrees + 35;
   const path =
@@ -194,13 +212,14 @@ export default class TransformHandleLayer {
   /**
    * Draws resize handles and rotate hit targets.
    *
-   * @param {ResizeBounds | { resizeBounds?: ResizeBounds, rotateFrame?: object } | null | undefined} options
+   * @param {ResizeBounds | { resizeBounds?: ResizeBounds, resizeFrame?: object, rotateFrame?: object } | null | undefined} options
    * @returns {void}
    */
   draw(options) {
-    const { resizeBounds, rotateFrame } = normalizeDrawOptions(options);
+    const { resizeBounds, resizeFrame, rotateFrame } =
+      normalizeDrawOptions(options);
 
-    if (!resizeBounds && !rotateFrame) {
+    if (!resizeFrame && !resizeBounds && !rotateFrame) {
       this.clear();
       return;
     }
@@ -218,10 +237,12 @@ export default class TransformHandleLayer {
     const halfSize = size / 2;
     const hitSize = Math.max(size, CORNER_HIT_SIZE / viewportScale);
     const halfHitSize = hitSize / 2;
-    const positions = resizeBounds ? getHandlePositions(resizeBounds) : {};
+    const positions = getResizeHandlePositions({ resizeBounds, resizeFrame });
+    const resizeCursors = getResizeCursors(resizeFrame);
 
     this.#drawResizeHandles({
       positions,
+      cursors: resizeCursors,
       viewport,
       size,
       halfSize,
@@ -232,12 +253,19 @@ export default class TransformHandleLayer {
     });
     this.#drawResizeFrame({
       bounds: resizeBounds,
+      frame: resizeFrame,
       viewport,
       viewportScale,
       strokeWidth,
       strokeColor: handleStyle.stroke,
     });
-    this.#drawEdgeTargets(resizeBounds, positions, viewportScale);
+    this.#drawEdgeTargets({
+      bounds: resizeBounds,
+      frame: resizeFrame,
+      positions,
+      cursors: resizeCursors,
+      viewportScale,
+    });
     this.#drawRotateTargets({
       frame: rotateFrame,
       viewport,
@@ -248,6 +276,7 @@ export default class TransformHandleLayer {
 
   #drawResizeHandles({
     positions,
+    cursors,
     viewport,
     size,
     halfSize,
@@ -283,6 +312,7 @@ export default class TransformHandleLayer {
           width: strokeWidth,
         });
       handle.position.set(localPosition.x, localPosition.y);
+      handle.cursor = cursors[key] ?? RESIZE_CURSORS[key] ?? 'default';
       handle.visible = true;
     });
   }
@@ -352,35 +382,57 @@ export default class TransformHandleLayer {
 
   #drawResizeFrame({
     bounds,
+    frame,
     viewport,
     viewportScale,
     strokeWidth,
     strokeColor,
   }) {
     if (!this._resizeFrame) return;
-    if (!bounds) {
+    if (!frame && !bounds) {
       this._resizeFrame.clear();
       this._resizeFrame.visible = false;
       return;
     }
 
-    const localRect = this.#toLocalRect(bounds, viewport, viewportScale);
     this._resizeFrame.clear();
-    this._resizeFrame
-      .rect(localRect.x, localRect.y, localRect.width, localRect.height)
-      .stroke({
-        color: strokeColor,
-        width: strokeWidth,
-      });
+    if (frame?.corners) {
+      this._resizeFrame
+        .poly(
+          frame.corners.map((corner) =>
+            this._transformer.toLocal(
+              new Point(corner.x, corner.y),
+              viewport ?? undefined,
+            ),
+          ),
+        )
+        .stroke({
+          color: strokeColor,
+          width: strokeWidth,
+        });
+    } else {
+      const localRect = this.#toLocalRect(bounds, viewport, viewportScale);
+      this._resizeFrame
+        .rect(localRect.x, localRect.y, localRect.width, localRect.height)
+        .stroke({
+          color: strokeColor,
+          width: strokeWidth,
+        });
+    }
     this._resizeFrame.visible = true;
   }
 
-  #drawEdgeTargets(bounds, positions, viewportScale) {
-    if (!bounds) {
+  #drawEdgeTargets({ bounds, frame, positions, cursors, viewportScale }) {
+    if (!frame && !bounds) {
       this._edgeMap.forEach((edge) => {
         edge.clear();
         edge.visible = false;
       });
+      return;
+    }
+
+    if (frame?.corners) {
+      this.#drawFrameEdgeTargets({ frame, positions, cursors, viewportScale });
       return;
     }
 
@@ -430,6 +482,43 @@ export default class TransformHandleLayer {
         color: this._getHandleStyle().fill,
         alpha: 0.001,
       });
+      edge.cursor = cursors[key] ?? RESIZE_CURSORS[key] ?? 'default';
+      edge.visible = Boolean(positions[key]);
+    });
+  }
+
+  #drawFrameEdgeTargets({ frame, positions, cursors, viewportScale }) {
+    const edgeHitWidth = EDGE_HIT_WIDTH / viewportScale;
+    const viewport = this._getViewport();
+    const edgeCorners = {
+      top: [frame.corners[0], frame.corners[1]],
+      right: [frame.corners[1], frame.corners[2]],
+      bottom: [frame.corners[3], frame.corners[2]],
+      left: [frame.corners[0], frame.corners[3]],
+    };
+
+    this._edgeMap.forEach((edge, key) => {
+      const corners = edgeCorners[key];
+      if (!corners) {
+        edge.visible = false;
+        return;
+      }
+      const start = this._transformer.toLocal(
+        new Point(corners[0].x, corners[0].y),
+        viewport ?? undefined,
+      );
+      const end = this._transformer.toLocal(
+        new Point(corners[1].x, corners[1].y),
+        viewport ?? undefined,
+      );
+
+      edge.clear();
+      edge.poly([start, end]).stroke({
+        color: this._getHandleStyle().fill,
+        alpha: 0.001,
+        width: edgeHitWidth,
+      });
+      edge.cursor = cursors[key] ?? RESIZE_CURSORS[key] ?? 'default';
       edge.visible = Boolean(positions[key]);
     });
   }
@@ -525,8 +614,55 @@ export default class TransformHandleLayer {
 
 const normalizeDrawOptions = (options) => {
   if (!options) return {};
-  if ('resizeBounds' in options || 'rotateFrame' in options) return options;
+  if (
+    'resizeBounds' in options ||
+    'resizeFrame' in options ||
+    'rotateFrame' in options
+  )
+    return options;
   return { resizeBounds: options };
+};
+
+const getResizeHandlePositions = ({ resizeBounds, resizeFrame }) => {
+  if (resizeFrame?.corners) {
+    return getFrameHandlePositions(resizeFrame);
+  }
+  return resizeBounds ? getHandlePositions(resizeBounds) : {};
+};
+
+const getFrameHandlePositions = (frame) => {
+  const corners = getCornerMap(frame.corners);
+  return {
+    ...corners,
+    top: midpoint(corners['top-left'], corners['top-right']),
+    right: midpoint(corners['top-right'], corners['bottom-right']),
+    bottom: midpoint(corners['bottom-left'], corners['bottom-right']),
+    left: midpoint(corners['top-left'], corners['bottom-left']),
+  };
+};
+
+const getResizeCursors = (frame) => {
+  const rotationDegrees = frame?.rotation
+    ? (frame.rotation * 180) / Math.PI
+    : 0;
+
+  return Object.fromEntries(
+    Object.entries(RESIZE_CURSOR_ANGLES).map(([handle, angle]) => [
+      handle,
+      getResizeCursorForAngle(angle + rotationDegrees),
+    ]),
+  );
+};
+
+const getResizeCursorForAngle = (angle) => {
+  const normalized = ((angle % 180) + 180) % 180;
+  return createResizeCursor(normalized);
+};
+
+const getResizeCursorFallback = (angle) => {
+  const normalized = ((angle % 180) + 180) % 180;
+  const step = Math.round(normalized / 45) % 4;
+  return ['ew-resize', 'nwse-resize', 'ns-resize', 'nesw-resize'][step];
 };
 
 const getCornerMap = (corners) => ({
@@ -534,6 +670,11 @@ const getCornerMap = (corners) => ({
   'top-right': corners[1],
   'bottom-right': corners[2],
   'bottom-left': corners[3],
+});
+
+const midpoint = (a, b) => ({
+  x: (a.x + b.x) / 2,
+  y: (a.y + b.y) / 2,
 });
 
 const normalizeVector = ({ x, y }) => {

--- a/src/transformer/TransformHandleLayer.js
+++ b/src/transformer/TransformHandleLayer.js
@@ -21,7 +21,7 @@ import { getHandlePositions } from './resize-utils';
  * @property {number} size
  */
 
-const HANDLE_CURSORS = {
+const RESIZE_CURSORS = {
   'top-left': 'nwse-resize',
   top: 'ns-resize',
   'top-right': 'nesw-resize',
@@ -31,6 +31,7 @@ const HANDLE_CURSORS = {
   'bottom-left': 'nesw-resize',
   left: 'ew-resize',
 };
+const ROTATE_CURSOR = 'grab';
 
 const CORNER_RESIZE_HANDLES = [
   'top-left',
@@ -41,15 +42,18 @@ const CORNER_RESIZE_HANDLES = [
 const EDGE_RESIZE_HANDLES = ['top', 'right', 'bottom', 'left'];
 const EDGE_HIT_WIDTH = 12;
 const CORNER_HIT_SIZE = 12;
+const ROTATE_HIT_SIZE = 18;
+const ROTATE_HIT_OFFSET = 18;
 const RESIZE_FRAME_Z_INDEX = 0;
 const EDGE_TARGET_Z_INDEX = 1;
+const ROTATE_TARGET_Z_INDEX = 1;
 const CORNER_HANDLE_Z_INDEX = 2;
 
 /**
- * Renders resize corner handles and edge hit targets onto a dedicated layer.
+ * Renders transformer handles and hit targets onto a dedicated layer.
  * This class is UI-only and delegates gesture handling through callback hooks.
  */
-export default class ResizeHandleLayer {
+export default class TransformHandleLayer {
   /**
    * @private
    * @type {PIXI.Container}
@@ -84,7 +88,13 @@ export default class ResizeHandleLayer {
    * @private
    * @type {(handle: ResizeHandleName, event: import('pixi.js').FederatedPointerEvent) => void}
    */
-  _onHandlePointerDown;
+  _onResizePointerDown;
+
+  /**
+   * @private
+   * @type {(handle: ResizeHandleName, event: import('pixi.js').FederatedPointerEvent) => void}
+   */
+  _onRotatePointerDown;
 
   /**
    * @private
@@ -100,6 +110,12 @@ export default class ResizeHandleLayer {
 
   /**
    * @private
+   * @type {Map<ResizeHandleName, PIXI.Graphics>}
+   */
+  _rotateMap = new Map();
+
+  /**
+   * @private
    * @type {PIXI.Graphics | null}
    */
   _resizeFrame = null;
@@ -111,7 +127,8 @@ export default class ResizeHandleLayer {
    * @param {() => import('pixi-viewport').Viewport | null} options.getViewport
    * @param {() => ResizeHandleStyle} options.getHandleStyle
    * @param {() => number} options.getStrokeWidth
-   * @param {(handle: ResizeHandleName, event: import('pixi.js').FederatedPointerEvent) => void} options.onHandlePointerDown
+   * @param {(handle: ResizeHandleName, event: import('pixi.js').FederatedPointerEvent) => void} options.onResizePointerDown
+   * @param {(handle: ResizeHandleName, event: import('pixi.js').FederatedPointerEvent) => void} options.onRotatePointerDown
    */
   constructor({
     transformer,
@@ -119,14 +136,16 @@ export default class ResizeHandleLayer {
     getViewport,
     getHandleStyle,
     getStrokeWidth,
-    onHandlePointerDown,
+    onResizePointerDown,
+    onRotatePointerDown = () => {},
   }) {
     this._transformer = transformer;
     this._layer = layer;
     this._getViewport = getViewport;
     this._getHandleStyle = getHandleStyle;
     this._getStrokeWidth = getStrokeWidth;
-    this._onHandlePointerDown = onHandlePointerDown;
+    this._onResizePointerDown = onResizePointerDown;
+    this._onRotatePointerDown = onRotatePointerDown;
   }
 
   /**
@@ -150,22 +169,31 @@ export default class ResizeHandleLayer {
       edge.clear();
       edge.visible = false;
     });
+
+    this._rotateMap.forEach((rotateTarget) => {
+      rotateTarget.clear();
+      rotateTarget.visible = false;
+      rotateTarget.hitArea = null;
+    });
   }
 
   /**
-   * Draws corner handles and edge hit targets for the given bounds.
+   * Draws resize handles and rotate hit targets.
    *
-   * @param {ResizeBounds | null | undefined} bounds
+   * @param {ResizeBounds | { resizeBounds?: ResizeBounds, rotateFrame?: object } | null | undefined} options
    * @returns {void}
    */
-  draw(bounds) {
-    if (!bounds) {
+  draw(options) {
+    const { resizeBounds, rotateFrame } = normalizeDrawOptions(options);
+
+    if (!resizeBounds && !rotateFrame) {
       this.clear();
       return;
     }
 
     this.#ensureHandles();
     this.#ensureEdges();
+    this.#ensureRotateTargets();
     this.#ensureResizeFrame();
 
     const viewport = this._getViewport();
@@ -176,8 +204,44 @@ export default class ResizeHandleLayer {
     const halfSize = size / 2;
     const hitSize = Math.max(size, CORNER_HIT_SIZE / viewportScale);
     const halfHitSize = hitSize / 2;
-    const positions = getHandlePositions(bounds);
+    const positions = resizeBounds ? getHandlePositions(resizeBounds) : {};
 
+    this.#drawResizeHandles({
+      positions,
+      viewport,
+      size,
+      halfSize,
+      hitSize,
+      halfHitSize,
+      handleStyle,
+      strokeWidth,
+    });
+    this.#drawResizeFrame({
+      bounds: resizeBounds,
+      viewport,
+      viewportScale,
+      strokeWidth,
+      strokeColor: handleStyle.stroke,
+    });
+    this.#drawEdgeTargets(resizeBounds, positions, viewportScale);
+    this.#drawRotateTargets({
+      frame: rotateFrame,
+      viewport,
+      viewportScale,
+      handleStyle,
+    });
+  }
+
+  #drawResizeHandles({
+    positions,
+    viewport,
+    size,
+    halfSize,
+    hitSize,
+    halfHitSize,
+    handleStyle,
+    strokeWidth,
+  }) {
     this._handleMap.forEach((handle, key) => {
       const position = positions[key];
       if (!position) {
@@ -207,15 +271,6 @@ export default class ResizeHandleLayer {
       handle.position.set(localPosition.x, localPosition.y);
       handle.visible = true;
     });
-
-    this.#drawResizeFrame({
-      bounds,
-      viewport,
-      viewportScale,
-      strokeWidth,
-      strokeColor: handleStyle.stroke,
-    });
-    this.#drawEdgeTargets(bounds, positions, viewportScale);
   }
 
   #ensureHandles() {
@@ -226,9 +281,9 @@ export default class ResizeHandleLayer {
       graphic.eventMode = 'static';
       graphic.zIndex = CORNER_HANDLE_Z_INDEX;
       graphic.label = `resize-handle:${handle}`;
-      graphic.cursor = HANDLE_CURSORS[handle] ?? 'default';
+      graphic.cursor = RESIZE_CURSORS[handle] ?? 'default';
       graphic.on('pointerdown', (event) =>
-        this._onHandlePointerDown(handle, event),
+        this._onResizePointerDown(handle, event),
       );
       this._handleMap.set(handle, graphic);
       this._layer.addChild(graphic);
@@ -243,11 +298,28 @@ export default class ResizeHandleLayer {
       graphic.eventMode = 'static';
       graphic.zIndex = EDGE_TARGET_Z_INDEX;
       graphic.label = `resize-edge:${handle}`;
-      graphic.cursor = HANDLE_CURSORS[handle] ?? 'default';
+      graphic.cursor = RESIZE_CURSORS[handle] ?? 'default';
       graphic.on('pointerdown', (event) =>
-        this._onHandlePointerDown(handle, event),
+        this._onResizePointerDown(handle, event),
       );
       this._edgeMap.set(handle, graphic);
+      this._layer.addChild(graphic);
+    });
+  }
+
+  #ensureRotateTargets() {
+    if (this._rotateMap.size > 0) return;
+
+    CORNER_RESIZE_HANDLES.forEach((handle) => {
+      const graphic = new Graphics();
+      graphic.eventMode = 'static';
+      graphic.zIndex = ROTATE_TARGET_Z_INDEX;
+      graphic.label = `rotate-handle:${handle}`;
+      graphic.cursor = ROTATE_CURSOR;
+      graphic.on('pointerdown', (event) =>
+        this._onRotatePointerDown(handle, event),
+      );
+      this._rotateMap.set(handle, graphic);
       this._layer.addChild(graphic);
     });
   }
@@ -272,6 +344,11 @@ export default class ResizeHandleLayer {
     strokeColor,
   }) {
     if (!this._resizeFrame) return;
+    if (!bounds) {
+      this._resizeFrame.clear();
+      this._resizeFrame.visible = false;
+      return;
+    }
 
     const localRect = this.#toLocalRect(bounds, viewport, viewportScale);
     this._resizeFrame.clear();
@@ -285,6 +362,14 @@ export default class ResizeHandleLayer {
   }
 
   #drawEdgeTargets(bounds, positions, viewportScale) {
+    if (!bounds) {
+      this._edgeMap.forEach((edge) => {
+        edge.clear();
+        edge.visible = false;
+      });
+      return;
+    }
+
     const edgeHitWidth = EDGE_HIT_WIDTH / viewportScale;
     const viewport = this._getViewport();
     const { x, y, width, height } = this.#toLocalRect(
@@ -335,6 +420,57 @@ export default class ResizeHandleLayer {
     });
   }
 
+  #drawRotateTargets({ frame, viewport, viewportScale, handleStyle }) {
+    if (!frame?.corners || !frame?.center) {
+      this._rotateMap.forEach((target) => {
+        target.clear();
+        target.visible = false;
+        target.hitArea = null;
+      });
+      return;
+    }
+
+    const hitSize = ROTATE_HIT_SIZE / viewportScale;
+    const halfHitSize = hitSize / 2;
+    const offset = ROTATE_HIT_OFFSET / viewportScale;
+    const positions = getCornerMap(frame.corners);
+
+    this._rotateMap.forEach((target, key) => {
+      const corner = positions[key];
+      if (!corner) {
+        target.visible = false;
+        return;
+      }
+
+      const direction = normalizeVector({
+        x: corner.x - frame.center.x,
+        y: corner.y - frame.center.y,
+      });
+      const targetPosition = {
+        x: corner.x + direction.x * offset,
+        y: corner.y + direction.y * offset,
+      };
+      const localPosition = this._transformer.toLocal(
+        new Point(targetPosition.x, targetPosition.y),
+        viewport ?? undefined,
+      );
+
+      target.hitArea = new Rectangle(
+        -halfHitSize,
+        -halfHitSize,
+        hitSize,
+        hitSize,
+      );
+      target.clear();
+      target.rect(-halfHitSize, -halfHitSize, hitSize, hitSize).fill({
+        color: handleStyle.fill,
+        alpha: 0.001,
+      });
+      target.position.set(localPosition.x, localPosition.y);
+      target.visible = true;
+    });
+  }
+
   #toLocalRect(bounds, viewport, viewportScale) {
     const minEdgeSize = 1 / viewportScale;
     const topLeft = this._transformer.toLocal(
@@ -372,3 +508,22 @@ export default class ResizeHandleLayer {
     };
   }
 }
+
+const normalizeDrawOptions = (options) => {
+  if (!options) return {};
+  if ('resizeBounds' in options || 'rotateFrame' in options) return options;
+  return { resizeBounds: options };
+};
+
+const getCornerMap = (corners) => ({
+  'top-left': corners[0],
+  'top-right': corners[1],
+  'bottom-right': corners[2],
+  'bottom-left': corners[3],
+});
+
+const normalizeVector = ({ x, y }) => {
+  const length = Math.hypot(x, y);
+  if (!length) return { x: 0, y: 0 };
+  return { x: x / length, y: y / length };
+};

--- a/src/transformer/TransformHandleLayer.js
+++ b/src/transformer/TransformHandleLayer.js
@@ -409,6 +409,7 @@ export default class TransformHandleLayer {
               viewport ?? undefined,
             ),
           ),
+          true,
         )
         .stroke({
           color: strokeColor,

--- a/src/transformer/TransformHandleLayer.js
+++ b/src/transformer/TransformHandleLayer.js
@@ -31,7 +31,21 @@ const RESIZE_CURSORS = {
   'bottom-left': 'nesw-resize',
   left: 'ew-resize',
 };
-const ROTATE_CURSOR = 'grab';
+
+const createRotateCursor = (degrees) => {
+  const rotation = degrees + 35;
+  const path =
+    'M482-160q-134 0-228-93t-94-227v-7l-36 36q-11 11-28 11t-28-11q-11-11-11-28t11-28l104-104q12-12 28-12t28 12l104 104q11 11 11 28t-11 28q-11 11-28 11t-28-11l-36-36v7q0 100 70.5 170T482-240q16 0 31.5-2t30.5-7q17-5 32 1t23 21q8 16 1.5 31.5T577-175q-23 8-47 11.5t-48 3.5Zm-4-560q-16 0-31.5 2t-30.5 7q-17 5-32.5-1T360-733q-8-15-1.5-30.5T381-784q24-8 48-12t49-4q134 0 228 93t94 227v7l36-36q11-11 28-11t28 11q11 11 11 28t-11 28L788-349q-12 12-28 12t-28-12L628-453q-11-11-11-28t11-28q11-11 28-11t28 11l36 36v-7q0-100-70.5-170T478-720Z';
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 -960 960 960"><g transform="rotate(${rotation} 480 -480)"><path d="${path}" fill="black" stroke="white" stroke-width="70" paint-order="stroke fill"/></g></svg>`;
+  return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 12 12, crosshair`;
+};
+
+const ROTATE_CURSORS = {
+  'top-left': createRotateCursor(-45),
+  'top-right': createRotateCursor(45),
+  'bottom-right': createRotateCursor(135),
+  'bottom-left': createRotateCursor(-135),
+};
 
 const CORNER_RESIZE_HANDLES = [
   'top-left',
@@ -315,7 +329,7 @@ export default class TransformHandleLayer {
       graphic.eventMode = 'static';
       graphic.zIndex = ROTATE_TARGET_Z_INDEX;
       graphic.label = `rotate-handle:${handle}`;
-      graphic.cursor = ROTATE_CURSOR;
+      graphic.cursor = ROTATE_CURSORS[handle] ?? 'crosshair';
       graphic.on('pointerdown', (event) =>
         this._onRotatePointerDown(handle, event),
       );

--- a/src/transformer/Transformer.js
+++ b/src/transformer/Transformer.js
@@ -6,9 +6,11 @@ import { getViewport } from '../utils/get';
 import { validate } from '../utils/validator';
 import { getSafeViewportScale } from '../utils/viewport';
 import ResizeGestureController from './ResizeGestureController';
-import ResizeHandleLayer from './ResizeHandleLayer';
+import RotateGestureController from './RotateGestureController';
 import { buildResizeContext } from './resize-context';
+import { buildRotateContext } from './rotate-context';
 import SelectionModel from './SelectionModel';
+import TransformHandleLayer from './TransformHandleLayer';
 import { Wireframe } from './Wireframe';
 
 const DEFAULT_WIREFRAME_STYLE = { thickness: 1.5, color: '#1099FF' };
@@ -35,7 +37,8 @@ const DEFAULT_HANDLE_STYLE = { fill: '#FFFFFF', stroke: '#1099FF', size: 8 };
  * @property {WireframeStyle} [wireframeStyle] - The style of the wireframe.
  * @property {BoundsDisplayMode} [boundsDisplayMode='all'] - The mode for displaying bounds.
  * @property {boolean} [resizeHandles=false] - Enable group resize handles.
- * @property {boolean} [resizeHistory=false] - Record resize changes to undo/redo history.
+ * @property {boolean} [rotateHandles=false] - Enable outside-corner rotate hit targets.
+ * @property {boolean} [transformHistory=false] - Record transform changes to undo/redo history.
  */
 
 const TransformerSchema = z
@@ -44,7 +47,8 @@ const TransformerSchema = z
     wireframeStyle: z.record(z.string(), z.unknown()),
     boundsDisplayMode: z.enum(['all', 'groupOnly', 'elementOnly', 'none']),
     resizeHandles: z.boolean(),
-    resizeHistory: z.boolean(),
+    rotateHandles: z.boolean(),
+    transformHistory: z.boolean(),
   })
   .partial();
 
@@ -95,24 +99,31 @@ export default class Transformer extends Container {
   _resizeHandles = false;
 
   /**
-   * Flag to record resize changes to undo/redo history.
+   * Flag to enable rotate handles for group bounds.
    * @private
    * @type {boolean}
    */
-  _resizeHistory = false;
+  _rotateHandles = false;
 
   /**
-   * The container holding resize handle graphics.
+   * Flag to record transform changes to undo/redo history.
+   * @private
+   * @type {boolean}
+   */
+  _transformHistory = false;
+
+  /**
+   * The container holding transform handle graphics.
    * @private
    * @type {PIXI.Container}
    */
-  _resizeHandleLayer;
+  _transformHandleLayer;
 
   /**
    * @private
    * @type {{ fill: string | number, stroke: string | number, size: number }}
    */
-  _resizeHandleStyle = { ...DEFAULT_HANDLE_STYLE };
+  _transformHandleStyle = { ...DEFAULT_HANDLE_STYLE };
 
   /**
    * Manages the state of the currently selected elements.
@@ -122,11 +133,11 @@ export default class Transformer extends Container {
   _selection;
 
   /**
-   * Handles drawing and hit-target rendering for resize handles.
+   * Handles drawing and hit-target rendering for transform handles.
    * @private
-   * @type {ResizeHandleLayer}
+   * @type {TransformHandleLayer}
    */
-  _resizeHandleRenderer;
+  _transformHandleRenderer;
 
   /**
    * Handles pointer gesture lifecycle for resizing.
@@ -134,6 +145,13 @@ export default class Transformer extends Container {
    * @type {ResizeGestureController}
    */
   _resizeGesture;
+
+  /**
+   * Handles pointer gesture lifecycle for rotating.
+   * @private
+   * @type {RotateGestureController}
+   */
+  _rotateGesture;
 
   /**
    * @param {TransformerOptions} [opts] - The options for the transformer.
@@ -146,18 +164,21 @@ export default class Transformer extends Container {
 
     this._selection = new SelectionModel();
     this.#wireframe = this.addChild(new Wireframe({ type: 'wireframe' }));
-    this._resizeHandleLayer = this.addChild(
-      new Container({ label: 'resize-handles', sortableChildren: true }),
+    this._transformHandleLayer = this.addChild(
+      new Container({ label: 'transform-handles', sortableChildren: true }),
     );
 
-    this._resizeHandleRenderer = new ResizeHandleLayer({
+    this._transformHandleRenderer = new TransformHandleLayer({
       transformer: this,
-      layer: this._resizeHandleLayer,
+      layer: this._transformHandleLayer,
       getViewport: () => this._viewport,
-      getHandleStyle: () => this._resizeHandleStyle,
+      getHandleStyle: () => this._transformHandleStyle,
       getStrokeWidth: () => this.wireframe.strokeStyle.width,
-      onHandlePointerDown: (handle, event) => {
+      onResizePointerDown: (handle, event) => {
         this._resizeGesture.begin(handle, event);
+      },
+      onRotatePointerDown: (handle, event) => {
+        this._rotateGesture.begin(handle, event);
       },
     });
 
@@ -165,7 +186,16 @@ export default class Transformer extends Container {
       getViewport: () => this._viewport,
       canStart: () => this.#shouldShowResizeHandles(),
       getResizeContext: () => this.#buildResizeContext(),
-      getResizeHistory: () => this._resizeHistory,
+      getTransformHistory: () => this._transformHistory,
+      emitUpdateElements: () => this.#emitUpdateElements(),
+      requestRender: this.update,
+    });
+
+    this._rotateGesture = new RotateGestureController({
+      getViewport: () => this._viewport,
+      canStart: () => this.#shouldShowRotateHandles(),
+      getRotateContext: () => this.#buildRotateContext(),
+      getTransformHistory: () => this._transformHistory,
       emitUpdateElements: () => this.#emitUpdateElements(),
       requestRender: this.update,
     });
@@ -271,7 +301,7 @@ export default class Transformer extends Container {
     this._wireframeStyle = Object.assign(this._wireframeStyle, value);
     this.wireframe.setStrokeStyle(this.wireframeStyle);
     if (this.wireframeStyle?.color != null) {
-      this._resizeHandleStyle.stroke = this.wireframeStyle.color;
+      this._transformHandleStyle.stroke = this.wireframeStyle.color;
     }
     this.update();
   }
@@ -287,22 +317,39 @@ export default class Transformer extends Container {
   set resizeHandles(value) {
     this._resizeHandles = Boolean(value);
     if (!this._resizeHandles) {
-      this._resizeHandleRenderer.clear();
       this._resizeGesture.end();
+      if (!this._rotateHandles) this._transformHandleRenderer.clear();
     }
     this.update();
   }
 
   /**
-   * Enables or disables recording resize changes to undo/redo history.
+   * Enables or disables rotate hit targets for group bounds.
    * @type {boolean}
    */
-  get resizeHistory() {
-    return this._resizeHistory;
+  get rotateHandles() {
+    return this._rotateHandles;
   }
 
-  set resizeHistory(value) {
-    this._resizeHistory = Boolean(value);
+  set rotateHandles(value) {
+    this._rotateHandles = Boolean(value);
+    if (!this._rotateHandles) {
+      this._rotateGesture.end();
+      if (!this._resizeHandles) this._transformHandleRenderer.clear();
+    }
+    this.update();
+  }
+
+  /**
+   * Enables or disables recording transform changes to undo/redo history.
+   * @type {boolean}
+   */
+  get transformHistory() {
+    return this._transformHistory;
+  }
+
+  set transformHistory(value) {
+    this._transformHistory = Boolean(value);
   }
 
   /**
@@ -318,7 +365,8 @@ export default class Transformer extends Container {
     }
 
     this._resizeGesture.destroy();
-    this._resizeHandleRenderer.clear();
+    this._rotateGesture.destroy();
+    this._transformHandleRenderer.clear();
     this.selection.destroy();
     super.destroy(options);
   }
@@ -340,19 +388,20 @@ export default class Transformer extends Container {
   draw() {
     const elements = this.elements;
     const resizeContext = this.#buildResizeContext(elements);
+    const rotateContext = this.#buildRotateContext(elements);
 
     this.wireframe.clear();
 
     if (this.#isEmptySelection(elements)) {
       this._renderDirty = false;
-      this._resizeHandleRenderer.clear();
+      this._transformHandleRenderer.clear();
       return;
     }
 
     this.#syncWireframeStrokeWidth();
     this.#drawElementBounds(elements);
     this.#drawGroupBounds(elements);
-    this.#drawResizeHandlesFor(resizeContext);
+    this.#drawTransformHandlesFor({ resizeContext, rotateContext });
     this._renderDirty = false;
   }
 
@@ -369,7 +418,9 @@ export default class Transformer extends Container {
   }
 
   #syncWireframeStrokeWidth() {
-    if (this.boundsDisplayMode === 'none' && !this._resizeHandles) return;
+    if (this.boundsDisplayMode === 'none' && !this.#shouldShowAnyHandles()) {
+      return;
+    }
 
     const viewportScale = getSafeViewportScale(this._viewport);
 
@@ -391,32 +442,55 @@ export default class Transformer extends Container {
   }
 
   #drawGroupBounds(elements) {
-    const shouldShowResizeHandles = this.#shouldShowResizeHandles();
+    const shouldShowHandles = this.#shouldShowAnyHandles();
     if (
       this.boundsDisplayMode !== 'all' &&
       this.boundsDisplayMode !== 'groupOnly' &&
-      !shouldShowResizeHandles
+      !shouldShowHandles
     ) {
       return;
     }
 
-    const groupBounds = calcGroupOrientedBounds(elements);
+    const groupBounds = this.#getGroupBounds(elements);
     if (groupBounds) {
       this.wireframe.drawBounds(groupBounds);
     }
   }
 
-  #drawResizeHandlesFor(resizeContext) {
-    if (!this.#shouldShowResizeHandles() || !resizeContext) {
-      this._resizeHandleRenderer.clear();
+  #getGroupBounds(elements) {
+    if (elements.length === 1) {
+      return calcOrientedBounds(elements[0]);
+    }
+
+    return calcGroupOrientedBounds(elements);
+  }
+
+  #drawTransformHandlesFor({ resizeContext, rotateContext }) {
+    const resizeBounds = this.#shouldShowResizeHandles()
+      ? resizeContext?.bounds
+      : null;
+    const rotateFrame = this.#shouldShowRotateHandles()
+      ? rotateContext?.frame
+      : null;
+
+    if (!resizeBounds && !rotateFrame) {
+      this._transformHandleRenderer.clear();
       return;
     }
 
-    this._resizeHandleRenderer.draw(resizeContext.bounds);
+    this._transformHandleRenderer.draw({ resizeBounds, rotateFrame });
   }
 
   #shouldShowResizeHandles() {
     return this._resizeHandles && this.boundsDisplayMode !== 'none';
+  }
+
+  #shouldShowRotateHandles() {
+    return this._rotateHandles && this.boundsDisplayMode !== 'none';
+  }
+
+  #shouldShowAnyHandles() {
+    return this.#shouldShowResizeHandles() || this.#shouldShowRotateHandles();
   }
 
   #emitUpdateElements({
@@ -429,6 +503,13 @@ export default class Transformer extends Container {
 
   #buildResizeContext(elements = this.elements) {
     return buildResizeContext({
+      elements,
+      viewport: this._viewport,
+    });
+  }
+
+  #buildRotateContext(elements = this.elements) {
+    return buildRotateContext({
       elements,
       viewport: this._viewport,
     });

--- a/src/transformer/Transformer.js
+++ b/src/transformer/Transformer.js
@@ -387,8 +387,6 @@ export default class Transformer extends Container {
    */
   draw() {
     const elements = this.elements;
-    const resizeContext = this.#buildResizeContext(elements);
-    const rotateContext = this.#buildRotateContext(elements);
 
     this.wireframe.clear();
 
@@ -401,7 +399,7 @@ export default class Transformer extends Container {
     this.#syncWireframeStrokeWidth();
     this.#drawElementBounds(elements);
     this.#drawGroupBounds(elements);
-    this.#drawTransformHandlesFor({ resizeContext, rotateContext });
+    this.#drawTransformHandlesFor(elements);
     this._renderDirty = false;
   }
 
@@ -465,16 +463,18 @@ export default class Transformer extends Container {
     return calcGroupOrientedBounds(elements);
   }
 
-  #drawTransformHandlesFor({ resizeContext, rotateContext }) {
-    const resizeBounds = this.#shouldShowResizeHandles()
-      ? resizeContext?.bounds
+  #drawTransformHandlesFor(elements) {
+    const shouldShowResizeHandles = this.#shouldShowResizeHandles();
+    const shouldShowRotateHandles = this.#shouldShowRotateHandles();
+    const resizeContext = shouldShowResizeHandles
+      ? this.#buildResizeContext(elements)
       : null;
-    const resizeFrame = this.#shouldShowResizeHandles()
-      ? resizeContext?.frame
+    const rotateContext = shouldShowRotateHandles
+      ? this.#buildRotateContext(elements)
       : null;
-    const rotateFrame = this.#shouldShowRotateHandles()
-      ? rotateContext?.frame
-      : null;
+    const resizeBounds = shouldShowResizeHandles ? resizeContext?.bounds : null;
+    const resizeFrame = shouldShowResizeHandles ? resizeContext?.frame : null;
+    const rotateFrame = shouldShowRotateHandles ? rotateContext?.frame : null;
 
     if (!resizeFrame && !rotateFrame) {
       this._transformHandleRenderer.clear();

--- a/src/transformer/Transformer.js
+++ b/src/transformer/Transformer.js
@@ -469,16 +469,23 @@ export default class Transformer extends Container {
     const resizeBounds = this.#shouldShowResizeHandles()
       ? resizeContext?.bounds
       : null;
+    const resizeFrame = this.#shouldShowResizeHandles()
+      ? resizeContext?.frame
+      : null;
     const rotateFrame = this.#shouldShowRotateHandles()
       ? rotateContext?.frame
       : null;
 
-    if (!resizeBounds && !rotateFrame) {
+    if (!resizeFrame && !rotateFrame) {
       this._transformHandleRenderer.clear();
       return;
     }
 
-    this._transformHandleRenderer.draw({ resizeBounds, rotateFrame });
+    this._transformHandleRenderer.draw({
+      resizeBounds,
+      resizeFrame,
+      rotateFrame,
+    });
   }
 
   #shouldShowResizeHandles() {

--- a/src/transformer/gesture-session.js
+++ b/src/transformer/gesture-session.js
@@ -1,0 +1,56 @@
+export default class GestureSession {
+  _getViewport;
+  _onMove;
+  _onUp;
+  _ownsMouseEdgesSession = false;
+
+  constructor({ getViewport, onMove, onUp }) {
+    this._getViewport = getViewport;
+    this._onMove = onMove;
+    this._onUp = onUp;
+  }
+
+  start() {
+    const viewport = this._getViewport();
+    if (!viewport) return;
+
+    this.stop();
+    this.#startMouseEdges();
+    viewport.on('pointermove', this._onMove);
+    viewport.on('pointerup', this._onUp);
+    viewport.on('pointerupoutside', this._onUp);
+  }
+
+  stop() {
+    this.#stopMouseEdges();
+
+    const viewport = this._getViewport();
+    if (!viewport) return;
+
+    viewport.off('pointermove', this._onMove);
+    viewport.off('pointerup', this._onUp);
+    viewport.off('pointerupoutside', this._onUp);
+  }
+
+  #startMouseEdges() {
+    const viewport = this._getViewport();
+    if (!viewport?.plugin?.start || this._ownsMouseEdgesSession) return;
+
+    const mouseEdgesPlugin = viewport?.plugins?.get?.('mouse-edges');
+    if (!mouseEdgesPlugin) return;
+
+    const wasPaused = Boolean(mouseEdgesPlugin.paused);
+    if (!wasPaused) return;
+
+    viewport.plugin.start('mouse-edges');
+    this._ownsMouseEdgesSession = true;
+  }
+
+  #stopMouseEdges() {
+    if (!this._ownsMouseEdgesSession) return;
+
+    const viewport = this._getViewport();
+    viewport?.plugin?.stop?.('mouse-edges');
+    this._ownsMouseEdgesSession = false;
+  }
+}

--- a/src/transformer/resize-apply.js
+++ b/src/transformer/resize-apply.js
@@ -1,6 +1,10 @@
 import { Point } from 'pixi.js';
 import { isResizableElement } from './resize-context';
-import { computeResize, resizeElementState } from './resize-utils';
+import {
+  computeResize,
+  resizeElementState,
+  snapSizeToUnit,
+} from './resize-utils';
 
 /**
  * @typedef {object} ResizeElementState
@@ -64,6 +68,13 @@ export const createResizeDelta = (startPoint, currentPoint) => ({
  * @returns {ResizeUpdate[]}
  */
 export const computeResizeUpdates = ({ activeResize, delta, keepRatio }) => {
+  if (
+    activeResize.frame?.mode === 'oriented' &&
+    activeResize.elementStates.length === 1
+  ) {
+    return computeOrientedResizeUpdates({ activeResize, delta, keepRatio });
+  }
+
   const resizeInfo = computeResize({
     bounds: activeResize.bounds,
     handle: activeResize.handle,
@@ -75,6 +86,81 @@ export const computeResizeUpdates = ({ activeResize, delta, keepRatio }) => {
     element: state.element,
     updatedState: resizeElementState(state, resizeInfo),
   }));
+};
+
+const computeOrientedResizeUpdates = ({ activeResize, delta, keepRatio }) => {
+  const state = activeResize.elementStates[0];
+  const geometry = getOrientedFrameGeometry(activeResize.frame);
+  const localDelta = projectDelta(delta, geometry);
+  const resizeInfo = computeResize({
+    bounds: {
+      x: 0,
+      y: 0,
+      width: geometry.width,
+      height: geometry.height,
+    },
+    handle: activeResize.handle,
+    delta: localDelta,
+    keepRatio,
+  });
+  const origin = frameLocalToViewport(
+    geometry,
+    resizeInfo.bounds.x,
+    resizeInfo.bounds.y,
+  );
+
+  return [
+    {
+      element: state.element,
+      updatedState: {
+        x: origin.x,
+        y: origin.y,
+        width: snapSizeToUnit(resizeInfo.bounds.width, state.width),
+        height: snapSizeToUnit(resizeInfo.bounds.height, state.height),
+      },
+    },
+  ];
+};
+
+const getOrientedFrameGeometry = (frame) => {
+  const [topLeft, topRight, , bottomLeft] = frame.corners;
+  const widthVector = {
+    x: topRight.x - topLeft.x,
+    y: topRight.y - topLeft.y,
+  };
+  const heightVector = {
+    x: bottomLeft.x - topLeft.x,
+    y: bottomLeft.y - topLeft.y,
+  };
+  const width = Math.hypot(widthVector.x, widthVector.y);
+  const height = Math.hypot(heightVector.x, heightVector.y);
+
+  return {
+    origin: topLeft,
+    xAxis: normalizeVector(widthVector),
+    yAxis: normalizeVector(heightVector),
+    width,
+    height,
+  };
+};
+
+const projectDelta = (delta, geometry) => ({
+  x: delta.x * geometry.xAxis.x + delta.y * geometry.xAxis.y,
+  y: delta.x * geometry.yAxis.x + delta.y * geometry.yAxis.y,
+});
+
+const frameLocalToViewport = (geometry, x, y) => ({
+  x: geometry.origin.x + geometry.xAxis.x * x + geometry.yAxis.x * y,
+  y: geometry.origin.y + geometry.xAxis.y * x + geometry.yAxis.y * y,
+});
+
+const normalizeVector = (vector) => {
+  const length = Math.hypot(vector.x, vector.y);
+  if (!length) return { x: 0, y: 0 };
+  return {
+    x: vector.x / length,
+    y: vector.y / length,
+  };
 };
 
 /**

--- a/src/transformer/resize-context.js
+++ b/src/transformer/resize-context.js
@@ -1,5 +1,8 @@
 import { isResizableCandidate } from '../utils/interaction-locks';
-import { getBoundsFromPoints, getObjectLocalCorners } from '../utils/transform';
+import {
+  getBoundsFromPoints,
+  getObjectFrameLocalCorners,
+} from '../utils/transform';
 
 /**
  * @typedef {object} Bounds
@@ -54,7 +57,7 @@ export const normalizeBounds = (bounds) => ({
 export const getGroupBoundsInViewportSpace = ({ elements, viewport }) => {
   if (!viewport || !elements || elements.length === 0) return null;
   const corners = elements.flatMap((element) =>
-    getObjectLocalCorners(element, viewport),
+    getObjectFrameLocalCorners(element, viewport),
   );
   return getBoundsFromPoints(corners);
 };
@@ -63,7 +66,7 @@ const buildResizeFrame = ({ elements, viewport }) => {
   if (!viewport || !elements || elements.length === 0) return null;
 
   if (elements.length === 1) {
-    const corners = getObjectLocalCorners(elements[0], viewport);
+    const corners = getObjectFrameLocalCorners(elements[0], viewport);
     if (corners.length === 0) return null;
     const bounds = normalizeBounds(getBoundsFromPoints(corners));
     return {

--- a/src/transformer/resize-context.js
+++ b/src/transformer/resize-context.js
@@ -59,6 +59,37 @@ export const getGroupBoundsInViewportSpace = ({ elements, viewport }) => {
   return getBoundsFromPoints(corners);
 };
 
+const buildResizeFrame = ({ elements, viewport }) => {
+  if (!viewport || !elements || elements.length === 0) return null;
+
+  if (elements.length === 1) {
+    const corners = getObjectLocalCorners(elements[0], viewport);
+    if (corners.length === 0) return null;
+    const bounds = normalizeBounds(getBoundsFromPoints(corners));
+    return {
+      mode: 'oriented',
+      bounds,
+      corners,
+      center: getCenter(corners),
+      rotation: getFrameRotation(corners),
+    };
+  }
+
+  const bounds = normalizeBounds(
+    getGroupBoundsInViewportSpace({ elements, viewport }),
+  );
+  return {
+    mode: 'axis-aligned',
+    bounds,
+    corners: getAxisAlignedCorners(bounds),
+    center: {
+      x: bounds.x + bounds.width / 2,
+      y: bounds.y + bounds.height / 2,
+    },
+    rotation: 0,
+  };
+};
+
 /**
  * Builds resize context for the current selection.
  * Returns `null` when resize cannot start (no selection, no viewport, or no
@@ -67,7 +98,7 @@ export const getGroupBoundsInViewportSpace = ({ elements, viewport }) => {
  * @param {object} params
  * @param {PIXI.DisplayObject[]} params.elements
  * @param {import('pixi-viewport').Viewport | null} params.viewport
- * @returns {{ elements: PIXI.DisplayObject[], bounds: Bounds } | null}
+ * @returns {{ elements: PIXI.DisplayObject[], bounds: Bounds, frame: object } | null}
  */
 export const buildResizeContext = ({ elements, viewport }) => {
   if (!Array.isArray(elements) || elements.length === 0) return null;
@@ -81,8 +112,29 @@ export const buildResizeContext = ({ elements, viewport }) => {
   });
   if (!bounds) return null;
 
+  const frame = buildResizeFrame({ elements: resizableElements, viewport });
+  if (!frame) return null;
+
   return {
     elements: resizableElements,
     bounds: normalizeBounds(bounds),
+    frame,
   };
 };
+
+const getCenter = (corners) => ({
+  x: (corners[0].x + corners[1].x + corners[2].x + corners[3].x) / 4,
+  y: (corners[0].y + corners[1].y + corners[2].y + corners[3].y) / 4,
+});
+
+const getFrameRotation = (corners) => {
+  if (corners.length < 2) return 0;
+  return Math.atan2(corners[1].y - corners[0].y, corners[1].x - corners[0].x);
+};
+
+const getAxisAlignedCorners = (bounds) => [
+  { x: bounds.x, y: bounds.y },
+  { x: bounds.x + bounds.width, y: bounds.y },
+  { x: bounds.x + bounds.width, y: bounds.y + bounds.height },
+  { x: bounds.x, y: bounds.y + bounds.height },
+];

--- a/src/transformer/resize-context.test.js
+++ b/src/transformer/resize-context.test.js
@@ -80,13 +80,23 @@ describe('buildResizeContext', () => {
       viewport: { id: 'viewport' },
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       elements: [unlockedRect],
       bounds: {
         x: 20,
         y: 20,
         width: 20,
         height: 30,
+      },
+      frame: {
+        mode: 'oriented',
+        bounds: {
+          x: 20,
+          y: 20,
+          width: 20,
+          height: 30,
+        },
+        center: { x: 30, y: 35 },
       },
     });
   });

--- a/src/transformer/resize-context.test.js
+++ b/src/transformer/resize-context.test.js
@@ -16,7 +16,7 @@ vi.mock('../utils/transform', () => ({
       height: Math.max(...ys) - Math.min(...ys),
     };
   }),
-  getObjectLocalCorners: vi.fn((element) => element.corners ?? []),
+  getObjectFrameLocalCorners: vi.fn((element) => element.corners ?? []),
 }));
 
 import { buildResizeContext } from './resize-context';

--- a/src/transformer/resize-utils.js
+++ b/src/transformer/resize-utils.js
@@ -205,7 +205,7 @@ const createResizeResult = (geometry, axes, box) => {
 
 const SNAP_SIZE_EPSILON = 1e-6;
 
-const snapSizeToUnit = (rawSize, baseSize, minSize = 1) => {
+export const snapSizeToUnit = (rawSize, baseSize, minSize = 1) => {
   const minUnit = Math.max(1, Math.ceil(minSize));
   const safeRaw = Number.isFinite(rawSize) ? rawSize : minUnit;
   const safeBase = Number.isFinite(baseSize) ? baseSize : minUnit;

--- a/src/transformer/rotate-apply.js
+++ b/src/transformer/rotate-apply.js
@@ -100,9 +100,9 @@ const applyElementRotate = ({ element, updatedState, viewport, historyId }) => {
 
 export const getRotationKey = (element) => {
   const attrs = element?.props?.attrs;
-  if (attrs && Object.hasOwn(attrs, 'angle')) return 'angle';
   if (attrs && Object.hasOwn(attrs, 'rotation')) return 'rotation';
-  return 'rotation';
+  if (attrs && Object.hasOwn(attrs, 'angle')) return 'angle';
+  return 'angle';
 };
 
 const getRotationInRadians = (element, rotationKey) => {

--- a/src/transformer/rotate-apply.js
+++ b/src/transformer/rotate-apply.js
@@ -1,0 +1,116 @@
+import { Point } from 'pixi.js';
+import { getCentroid, getObjectLocalCorners } from '../utils/transform';
+import { isRotatableElement } from './rotate-context';
+import {
+  DEGREES_PER_RADIAN,
+  RADIANS_PER_DEGREE,
+  rotatePoint,
+} from './rotate-utils';
+
+/**
+ * @typedef {object} RotateElementState
+ * @property {PIXI.DisplayObject} element
+ * @property {{ x: number, y: number }} origin
+ * @property {{ x: number, y: number }} center
+ * @property {{ x: number, y: number }} centerOffset
+ * @property {'angle' | 'rotation'} rotationKey
+ * @property {number} rotation
+ */
+
+export const createRotateElementStates = ({ elements, viewport }) =>
+  elements.map((element) => {
+    const worldPosition = element.getGlobalPosition();
+    const origin = viewport.toLocal(worldPosition);
+    const corners = getObjectLocalCorners(element, viewport);
+    const center = getCentroid(corners);
+    const rotationKey = getRotationKey(element);
+
+    return {
+      element,
+      origin,
+      center,
+      centerOffset: {
+        x: center.x - origin.x,
+        y: center.y - origin.y,
+      },
+      rotationKey,
+      rotation: getRotationInRadians(element, rotationKey),
+    };
+  });
+
+export const computeRotateUpdates = ({ activeRotate, deltaAngle }) =>
+  activeRotate.elementStates.map((state) => ({
+    element: state.element,
+    updatedState: rotateElementState(state, {
+      center: activeRotate.frame.center,
+      deltaAngle,
+    }),
+  }));
+
+export const rotateElementState = (state, { center, deltaAngle }) => {
+  const rotatedCenter = rotatePoint(state.center, center, deltaAngle);
+  const rotatedOffset = rotatePoint(
+    state.centerOffset,
+    { x: 0, y: 0 },
+    deltaAngle,
+  );
+  const rotation = state.rotation + deltaAngle;
+
+  return {
+    x: rotatedCenter.x - rotatedOffset.x,
+    y: rotatedCenter.y - rotatedOffset.y,
+    rotationKey: state.rotationKey,
+    rotation:
+      state.rotationKey === 'angle' ? rotation * DEGREES_PER_RADIAN : rotation,
+  };
+};
+
+export const applyRotateUpdates = ({ updates, viewport, historyId }) => {
+  updates.forEach(({ element, updatedState }) => {
+    applyElementRotate({
+      element,
+      updatedState,
+      viewport,
+      historyId,
+    });
+  });
+};
+
+const applyElementRotate = ({ element, updatedState, viewport, historyId }) => {
+  if (!element || !isRotatableElement(element)) return;
+
+  const parent = element.parent;
+  const localPosition = parent
+    ? parent.toLocal(
+        new Point(updatedState.x, updatedState.y),
+        viewport ?? undefined,
+      )
+    : new Point(updatedState.x, updatedState.y);
+
+  const changes = {
+    attrs: {
+      x: localPosition.x,
+      y: localPosition.y,
+      [updatedState.rotationKey]: updatedState.rotation,
+    },
+  };
+
+  element.apply(changes, historyId ? { historyId } : undefined);
+};
+
+export const getRotationKey = (element) => {
+  const attrs = element?.props?.attrs;
+  if (attrs && Object.hasOwn(attrs, 'angle')) return 'angle';
+  if (attrs && Object.hasOwn(attrs, 'rotation')) return 'rotation';
+  return 'rotation';
+};
+
+const getRotationInRadians = (element, rotationKey) => {
+  if (rotationKey === 'angle') {
+    return (
+      Number(element?.angle ?? element?.props?.attrs?.angle ?? 0) *
+      RADIANS_PER_DEGREE
+    );
+  }
+  return Number(element?.rotation ?? element?.props?.attrs?.rotation ?? 0);
+};

--- a/src/transformer/rotate-apply.js
+++ b/src/transformer/rotate-apply.js
@@ -1,5 +1,5 @@
 import { Point } from 'pixi.js';
-import { getCentroid, getObjectLocalCorners } from '../utils/transform';
+import { getCentroid, getObjectFrameLocalCorners } from '../utils/transform';
 import { isRotatableElement } from './rotate-context';
 import {
   DEGREES_PER_RADIAN,
@@ -21,7 +21,7 @@ export const createRotateElementStates = ({ elements, viewport }) =>
   elements.map((element) => {
     const worldPosition = element.getGlobalPosition();
     const origin = viewport.toLocal(worldPosition);
-    const corners = getObjectLocalCorners(element, viewport);
+    const corners = getObjectFrameLocalCorners(element, viewport);
     const center = getCentroid(corners);
     const rotationKey = getRotationKey(element);
 

--- a/src/transformer/rotate-apply.test.js
+++ b/src/transformer/rotate-apply.test.js
@@ -5,7 +5,7 @@ vi.mock('../utils/transform', () => ({
     x: points.reduce((sum, point) => sum + point.x, 0) / points.length,
     y: points.reduce((sum, point) => sum + point.y, 0) / points.length,
   })),
-  getObjectLocalCorners: vi.fn((element) => element.corners ?? []),
+  getObjectFrameLocalCorners: vi.fn((element) => element.corners ?? []),
 }));
 
 import {

--- a/src/transformer/rotate-apply.test.js
+++ b/src/transformer/rotate-apply.test.js
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../utils/transform', () => ({
+  getCentroid: vi.fn((points) => ({
+    x: points.reduce((sum, point) => sum + point.x, 0) / points.length,
+    y: points.reduce((sum, point) => sum + point.y, 0) / points.length,
+  })),
+  getObjectLocalCorners: vi.fn((element) => element.corners ?? []),
+}));
+
+import {
+  applyRotateUpdates,
+  computeRotateUpdates,
+  createRotateElementStates,
+  getRotationKey,
+  rotateElementState,
+} from './rotate-apply';
+
+const createElement = ({
+  id = 'element',
+  attrs = {},
+  angle = 0,
+  rotation = 0,
+  isRotatable = true,
+  parent = null,
+  corners = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 10 },
+    { x: 0, y: 10 },
+  ],
+} = {}) => ({
+  id,
+  angle,
+  rotation,
+  props: { attrs },
+  parent,
+  corners,
+  constructor: { isRotatable },
+  getGlobalPosition: () => ({ x: attrs.x ?? 0, y: attrs.y ?? 0 }),
+  apply: vi.fn(),
+});
+
+const viewport = {
+  toLocal: (point) => ({ x: point.x, y: point.y }),
+};
+
+describe('rotate-apply', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves existing angle key', () => {
+    expect(getRotationKey(createElement({ attrs: { angle: 30 } }))).toBe(
+      'angle',
+    );
+  });
+
+  it('preserves existing rotation key and defaults to rotation', () => {
+    expect(getRotationKey(createElement({ attrs: { rotation: 0.5 } }))).toBe(
+      'rotation',
+    );
+    expect(getRotationKey(createElement())).toBe('rotation');
+  });
+
+  it('rotates element origin around a visible center using center offset', () => {
+    const updated = rotateElementState(
+      {
+        origin: { x: 0, y: 0 },
+        center: { x: 5, y: 5 },
+        centerOffset: { x: 5, y: 5 },
+        rotationKey: 'rotation',
+        rotation: 0,
+      },
+      { center: { x: 10, y: 5 }, deltaAngle: Math.PI / 2 },
+    );
+
+    expect(updated.x).toBeCloseTo(15);
+    expect(updated.y).toBeCloseTo(-5);
+    expect(updated.rotation).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('writes angle updates in degrees', () => {
+    const updated = rotateElementState(
+      {
+        origin: { x: 0, y: 0 },
+        center: { x: 5, y: 5 },
+        centerOffset: { x: 5, y: 5 },
+        rotationKey: 'angle',
+        rotation: 0,
+      },
+      { center: { x: 5, y: 5 }, deltaAngle: Math.PI / 2 },
+    );
+
+    expect(updated.rotation).toBeCloseTo(90);
+  });
+
+  it('captures element states from viewport-local origin and visible center', () => {
+    const element = createElement({ attrs: { x: 10, y: 20 } });
+    const [state] = createRotateElementStates({
+      elements: [element],
+      viewport,
+    });
+
+    expect(state.origin).toEqual({ x: 10, y: 20 });
+    expect(state.center).toEqual({ x: 5, y: 5 });
+    expect(state.centerOffset).toEqual({ x: -5, y: -15 });
+  });
+
+  it('computes and applies attrs-only rotate updates with shared history id', () => {
+    const element = createElement({ attrs: { x: 0, y: 0, rotation: 0 } });
+    const activeRotate = {
+      frame: { center: { x: 5, y: 5 } },
+      elementStates: createRotateElementStates({
+        elements: [element],
+        viewport,
+      }),
+    };
+    const updates = computeRotateUpdates({
+      activeRotate,
+      deltaAngle: Math.PI / 2,
+    });
+
+    applyRotateUpdates({ updates, viewport, historyId: 'history-1' });
+
+    expect(element.apply).toHaveBeenCalledWith(
+      {
+        attrs: {
+          x: 10,
+          y: 0,
+          rotation: Math.PI / 2,
+        },
+      },
+      { historyId: 'history-1' },
+    );
+  });
+
+  it('maps updated origin through parent local space', () => {
+    const parent = {
+      toLocal: vi.fn((point) => ({ x: point.x - 100, y: point.y - 100 })),
+    };
+    const element = createElement({ parent });
+
+    applyRotateUpdates({
+      updates: [
+        {
+          element,
+          updatedState: {
+            x: 120,
+            y: 130,
+            rotationKey: 'rotation',
+            rotation: 1,
+          },
+        },
+      ],
+      viewport,
+    });
+
+    expect(element.apply).toHaveBeenCalledWith(
+      {
+        attrs: { x: 20, y: 30, rotation: 1 },
+      },
+      undefined,
+    );
+  });
+});

--- a/src/transformer/rotate-apply.test.js
+++ b/src/transformer/rotate-apply.test.js
@@ -56,11 +56,14 @@ describe('rotate-apply', () => {
     );
   });
 
-  it('preserves existing rotation key and defaults to rotation', () => {
+  it('preserves existing rotation key and falls back to angle', () => {
     expect(getRotationKey(createElement({ attrs: { rotation: 0.5 } }))).toBe(
       'rotation',
     );
-    expect(getRotationKey(createElement())).toBe('rotation');
+    expect(
+      getRotationKey(createElement({ attrs: { rotation: 0.5, angle: 30 } })),
+    ).toBe('rotation');
+    expect(getRotationKey(createElement())).toBe('angle');
   });
 
   it('rotates element origin around a visible center using center offset', () => {

--- a/src/transformer/rotate-context.js
+++ b/src/transformer/rotate-context.js
@@ -2,7 +2,7 @@ import { isRotatableCandidate } from '../utils/interaction-locks';
 import {
   getBoundsFromPoints,
   getCentroid,
-  getObjectLocalCorners,
+  getObjectFrameLocalCorners,
 } from '../utils/transform';
 import { normalizeBounds } from './resize-context';
 
@@ -31,7 +31,7 @@ export const buildTransformFrame = ({ elements, viewport }) => {
   if (!viewport || !elements || elements.length === 0) return null;
 
   if (elements.length === 1) {
-    const corners = getObjectLocalCorners(elements[0], viewport);
+    const corners = getObjectFrameLocalCorners(elements[0], viewport);
     if (corners.length === 0) return null;
     const bounds = normalizeBounds(getBoundsFromPoints(corners));
     const center = getCentroid(corners);
@@ -45,7 +45,7 @@ export const buildTransformFrame = ({ elements, viewport }) => {
   }
 
   const allCorners = elements.flatMap((element) =>
-    getObjectLocalCorners(element, viewport),
+    getObjectFrameLocalCorners(element, viewport),
   );
   if (allCorners.length === 0) return null;
 

--- a/src/transformer/rotate-context.js
+++ b/src/transformer/rotate-context.js
@@ -78,7 +78,7 @@ export const buildRotateContext = ({ elements, viewport }) => {
   const rotatableElements = getRotatableElements(elements, viewport);
   if (rotatableElements.length === 0) return null;
 
-  const frame = buildTransformFrame({ elements: rotatableElements, viewport });
+  const frame = buildTransformFrame({ elements, viewport });
   if (!frame) return null;
 
   return {

--- a/src/transformer/rotate-context.js
+++ b/src/transformer/rotate-context.js
@@ -1,0 +1,100 @@
+import { isRotatableCandidate } from '../utils/interaction-locks';
+import {
+  getBoundsFromPoints,
+  getCentroid,
+  getObjectLocalCorners,
+} from '../utils/transform';
+import { normalizeBounds } from './resize-context';
+
+/**
+ * Returns whether an element is rotatable by Transformer.
+ * Rotatability is controlled by the static `isRotatable` flag on the class.
+ *
+ * @param {PIXI.DisplayObject} element
+ * @returns {boolean}
+ */
+export const isRotatableElement = (element, stopAt = null) =>
+  isRotatableCandidate(element, stopAt);
+
+/**
+ * Filters an element list to only rotatable elements.
+ *
+ * @param {PIXI.DisplayObject[]} elements
+ * @returns {PIXI.DisplayObject[]}
+ */
+export const getRotatableElements = (elements, stopAt = null) => {
+  if (!Array.isArray(elements) || elements.length === 0) return [];
+  return elements.filter((element) => isRotatableElement(element, stopAt));
+};
+
+export const buildTransformFrame = ({ elements, viewport }) => {
+  if (!viewport || !elements || elements.length === 0) return null;
+
+  if (elements.length === 1) {
+    const corners = getObjectLocalCorners(elements[0], viewport);
+    if (corners.length === 0) return null;
+    const bounds = normalizeBounds(getBoundsFromPoints(corners));
+    const center = getCentroid(corners);
+    return {
+      mode: 'oriented',
+      bounds,
+      corners,
+      center,
+      rotation: getFrameRotation(corners),
+    };
+  }
+
+  const allCorners = elements.flatMap((element) =>
+    getObjectLocalCorners(element, viewport),
+  );
+  if (allCorners.length === 0) return null;
+
+  const bounds = normalizeBounds(getBoundsFromPoints(allCorners));
+  const corners = getAxisAlignedCorners(bounds);
+  return {
+    mode: 'axis-aligned',
+    bounds,
+    corners,
+    center: {
+      x: bounds.x + bounds.width / 2,
+      y: bounds.y + bounds.height / 2,
+    },
+    rotation: 0,
+  };
+};
+
+/**
+ * Builds rotate context for the current selection.
+ * Returns `null` when rotation cannot start.
+ *
+ * @param {object} params
+ * @param {PIXI.DisplayObject[]} params.elements
+ * @param {import('pixi-viewport').Viewport | null} params.viewport
+ * @returns {{ elements: PIXI.DisplayObject[], frame: object } | null}
+ */
+export const buildRotateContext = ({ elements, viewport }) => {
+  if (!Array.isArray(elements) || elements.length === 0) return null;
+
+  const rotatableElements = getRotatableElements(elements, viewport);
+  if (rotatableElements.length === 0) return null;
+
+  const frame = buildTransformFrame({ elements: rotatableElements, viewport });
+  if (!frame) return null;
+
+  return {
+    elements: rotatableElements,
+    frame,
+  };
+};
+
+export const getAxisAlignedCorners = (bounds) => [
+  { x: bounds.x, y: bounds.y },
+  { x: bounds.x + bounds.width, y: bounds.y },
+  { x: bounds.x + bounds.width, y: bounds.y + bounds.height },
+  { x: bounds.x, y: bounds.y + bounds.height },
+];
+
+const getFrameRotation = (corners) => {
+  if (corners.length < 2) return 0;
+  return Math.atan2(corners[1].y - corners[0].y, corners[1].x - corners[0].x);
+};

--- a/src/transformer/rotate-context.test.js
+++ b/src/transformer/rotate-context.test.js
@@ -16,7 +16,7 @@ vi.mock('../utils/transform', () => ({
     x: points.reduce((sum, point) => sum + point.x, 0) / points.length,
     y: points.reduce((sum, point) => sum + point.y, 0) / points.length,
   })),
-  getObjectLocalCorners: vi.fn((element) => element.corners ?? []),
+  getObjectFrameLocalCorners: vi.fn((element) => element.corners ?? []),
 }));
 
 import { buildRotateContext } from './rotate-context';

--- a/src/transformer/rotate-context.test.js
+++ b/src/transformer/rotate-context.test.js
@@ -72,11 +72,17 @@ describe('buildRotateContext', () => {
     expect(result).toBeNull();
   });
 
-  it('excludes rotatable elements under locked ancestors', () => {
+  it('uses the full selection frame while mutating only unlocked rotatable elements', () => {
     const lockedGroup = { props: { locked: true }, parent: null };
     const lockedChild = createElement({
       id: 'locked-child',
       parent: lockedGroup,
+      corners: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ],
     });
     const unlockedRect = createElement({
       id: 'unlocked-rect',
@@ -95,9 +101,36 @@ describe('buildRotateContext', () => {
 
     expect(result.elements).toEqual([unlockedRect]);
     expect(result.frame).toMatchObject({
-      mode: 'oriented',
-      bounds: { x: 20, y: 20, width: 20, height: 30 },
-      center: { x: 30, y: 35 },
+      mode: 'axis-aligned',
+      bounds: { x: 0, y: 0, width: 40, height: 50 },
+      center: { x: 20, y: 25 },
+      rotation: 0,
+    });
+  });
+
+  it('uses the full mixed selection frame when non-rotatable elements are selected', () => {
+    const rotatable = createElement({ id: 'rotatable' });
+    const nonRotatable = createElement({
+      id: 'item',
+      isRotatable: false,
+      corners: [
+        { x: 100, y: 100 },
+        { x: 130, y: 100 },
+        { x: 130, y: 140 },
+        { x: 100, y: 140 },
+      ],
+    });
+
+    const result = buildRotateContext({
+      elements: [rotatable, nonRotatable],
+      viewport: { id: 'viewport' },
+    });
+
+    expect(result.elements).toEqual([rotatable]);
+    expect(result.frame).toMatchObject({
+      mode: 'axis-aligned',
+      bounds: { x: 0, y: 0, width: 130, height: 140 },
+      center: { x: 65, y: 70 },
       rotation: 0,
     });
   });

--- a/src/transformer/rotate-context.test.js
+++ b/src/transformer/rotate-context.test.js
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../utils/transform', () => ({
+  getBoundsFromPoints: vi.fn((points) => {
+    if (!points.length) return null;
+    const xs = points.map((point) => point.x);
+    const ys = points.map((point) => point.y);
+    return {
+      x: Math.min(...xs),
+      y: Math.min(...ys),
+      width: Math.max(...xs) - Math.min(...xs),
+      height: Math.max(...ys) - Math.min(...ys),
+    };
+  }),
+  getCentroid: vi.fn((points) => ({
+    x: points.reduce((sum, point) => sum + point.x, 0) / points.length,
+    y: points.reduce((sum, point) => sum + point.y, 0) / points.length,
+  })),
+  getObjectLocalCorners: vi.fn((element) => element.corners ?? []),
+}));
+
+import { buildRotateContext } from './rotate-context';
+
+const createElement = ({
+  id,
+  locked = false,
+  isRotatable = true,
+  corners = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 10, y: 20 },
+    { x: 0, y: 20 },
+  ],
+  parent = null,
+} = {}) => ({
+  id,
+  props: { locked },
+  corners,
+  parent,
+  constructor: { isRotatable },
+});
+
+describe('buildRotateContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for an empty selection', () => {
+    const result = buildRotateContext({
+      elements: [],
+      viewport: { id: 'viewport' },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when selection has no rotatable elements', () => {
+    const result = buildRotateContext({
+      elements: [createElement({ id: 'item', isRotatable: false })],
+      viewport: { id: 'viewport' },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when all selected rotatable elements are locked', () => {
+    const result = buildRotateContext({
+      elements: [createElement({ id: 'locked', locked: true })],
+      viewport: { id: 'viewport' },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('excludes rotatable elements under locked ancestors', () => {
+    const lockedGroup = { props: { locked: true }, parent: null };
+    const lockedChild = createElement({
+      id: 'locked-child',
+      parent: lockedGroup,
+    });
+    const unlockedRect = createElement({
+      id: 'unlocked-rect',
+      corners: [
+        { x: 20, y: 20 },
+        { x: 40, y: 20 },
+        { x: 40, y: 50 },
+        { x: 20, y: 50 },
+      ],
+    });
+
+    const result = buildRotateContext({
+      elements: [lockedChild, unlockedRect],
+      viewport: { id: 'viewport' },
+    });
+
+    expect(result.elements).toEqual([unlockedRect]);
+    expect(result.frame).toMatchObject({
+      mode: 'oriented',
+      bounds: { x: 20, y: 20, width: 20, height: 30 },
+      center: { x: 30, y: 35 },
+      rotation: 0,
+    });
+  });
+
+  it('builds an oriented frame for one rotatable element', () => {
+    const result = buildRotateContext({
+      elements: [
+        createElement({
+          id: 'rotated',
+          corners: [
+            { x: 0, y: 0 },
+            { x: 10, y: 10 },
+            { x: 0, y: 20 },
+            { x: -10, y: 10 },
+          ],
+        }),
+      ],
+      viewport: { id: 'viewport' },
+    });
+
+    expect(result.frame.mode).toBe('oriented');
+    expect(result.frame.rotation).toBeCloseTo(Math.PI / 4);
+    expect(result.frame.center).toEqual({ x: 0, y: 10 });
+  });
+
+  it('builds an axis-aligned frame for multiple rotatable elements', () => {
+    const result = buildRotateContext({
+      elements: [
+        createElement({ id: 'left' }),
+        createElement({
+          id: 'right',
+          corners: [
+            { x: 20, y: 10 },
+            { x: 50, y: 10 },
+            { x: 50, y: 30 },
+            { x: 20, y: 30 },
+          ],
+        }),
+      ],
+      viewport: { id: 'viewport' },
+    });
+
+    expect(result.frame).toEqual({
+      mode: 'axis-aligned',
+      bounds: { x: 0, y: 0, width: 50, height: 30 },
+      corners: [
+        { x: 0, y: 0 },
+        { x: 50, y: 0 },
+        { x: 50, y: 30 },
+        { x: 0, y: 30 },
+      ],
+      center: { x: 25, y: 15 },
+      rotation: 0,
+    });
+  });
+});

--- a/src/transformer/rotate-utils.js
+++ b/src/transformer/rotate-utils.js
@@ -20,12 +20,16 @@ export const computeRotationDelta = ({
   startPoint,
   currentPoint,
   snap = false,
+  snapBaseAngle = 0,
   snapStep = ANGLE_SNAP_STEP,
 }) => {
   const delta = normalizeAngleDelta(
     getAngle(center, currentPoint) - getAngle(center, startPoint),
   );
-  return snap ? snapAngle(delta, snapStep) : delta;
+  if (!snap) return delta;
+  return normalizeAngleDelta(
+    snapAngle(snapBaseAngle + delta, snapStep) - snapBaseAngle,
+  );
 };
 
 export const rotatePoint = (point, center, angle) => {

--- a/src/transformer/rotate-utils.js
+++ b/src/transformer/rotate-utils.js
@@ -1,0 +1,40 @@
+export const ANGLE_SNAP_STEP = Math.PI / 12;
+export const DEGREES_PER_RADIAN = 180 / Math.PI;
+export const RADIANS_PER_DEGREE = Math.PI / 180;
+
+export const getAngle = (center, point) =>
+  Math.atan2(point.y - center.y, point.x - center.x);
+
+export const normalizeAngleDelta = (angle) => {
+  let normalized = angle;
+  while (normalized <= -Math.PI) normalized += Math.PI * 2;
+  while (normalized > Math.PI) normalized -= Math.PI * 2;
+  return normalized;
+};
+
+export const snapAngle = (angle, step = ANGLE_SNAP_STEP) =>
+  Math.round(angle / step) * step;
+
+export const computeRotationDelta = ({
+  center,
+  startPoint,
+  currentPoint,
+  snap = false,
+  snapStep = ANGLE_SNAP_STEP,
+}) => {
+  const delta = normalizeAngleDelta(
+    getAngle(center, currentPoint) - getAngle(center, startPoint),
+  );
+  return snap ? snapAngle(delta, snapStep) : delta;
+};
+
+export const rotatePoint = (point, center, angle) => {
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const dx = point.x - center.x;
+  const dy = point.y - center.y;
+  return {
+    x: center.x + dx * cos - dy * sin,
+    y: center.y + dx * sin + dy * cos,
+  };
+};

--- a/src/transformer/rotate-utils.test.js
+++ b/src/transformer/rotate-utils.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ANGLE_SNAP_STEP,
+  computeRotationDelta,
+  normalizeAngleDelta,
+  rotatePoint,
+  snapAngle,
+} from './rotate-utils';
+
+describe('rotate-utils', () => {
+  it('computes a rotation delta around a center point', () => {
+    const delta = computeRotationDelta({
+      center: { x: 0, y: 0 },
+      startPoint: { x: 10, y: 0 },
+      currentPoint: { x: 0, y: 10 },
+    });
+
+    expect(delta).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('snaps rotation delta to 15 degree increments', () => {
+    const delta = computeRotationDelta({
+      center: { x: 0, y: 0 },
+      startPoint: { x: 10, y: 0 },
+      currentPoint: { x: 8, y: 5 },
+      snap: true,
+    });
+
+    expect(delta % ANGLE_SNAP_STEP).toBeCloseTo(0);
+    expect(delta).toBeCloseTo(Math.PI / 6);
+  });
+
+  it('keeps unsnapped rotation delta when snap is false', () => {
+    const delta = computeRotationDelta({
+      center: { x: 0, y: 0 },
+      startPoint: { x: 10, y: 0 },
+      currentPoint: { x: 8, y: 5 },
+    });
+
+    expect(delta).not.toBeCloseTo(snapAngle(delta));
+  });
+
+  it('normalizes deltas around the 0/360 boundary', () => {
+    expect(normalizeAngleDelta((358 * Math.PI) / 180)).toBeCloseTo(
+      (-2 * Math.PI) / 180,
+    );
+  });
+
+  it('rotates a point around a center point', () => {
+    const rotated = rotatePoint({ x: 10, y: 0 }, { x: 0, y: 0 }, Math.PI / 2);
+
+    expect(rotated.x).toBeCloseTo(0);
+    expect(rotated.y).toBeCloseTo(10);
+  });
+});

--- a/src/transformer/rotate-utils.test.js
+++ b/src/transformer/rotate-utils.test.js
@@ -30,6 +30,22 @@ describe('rotate-utils', () => {
     expect(delta).toBeCloseTo(Math.PI / 6);
   });
 
+  it('snaps the final rotation angle instead of only the delta', () => {
+    const delta = computeRotationDelta({
+      center: { x: 0, y: 0 },
+      startPoint: { x: 10, y: 0 },
+      currentPoint: rotatePoint(
+        { x: 10, y: 0 },
+        { x: 0, y: 0 },
+        (60 * Math.PI) / 180,
+      ),
+      snap: true,
+      snapBaseAngle: (4 * Math.PI) / 180,
+    });
+
+    expect((4 * Math.PI) / 180 + delta).toBeCloseTo(Math.PI / 3);
+  });
+
   it('keeps unsnapped rotation delta when snap is false', () => {
     const delta = computeRotationDelta({
       center: { x: 0, y: 0 },

--- a/src/utils/interaction-locks.js
+++ b/src/utils/interaction-locks.js
@@ -24,3 +24,7 @@ export const isSelectableCandidate = (displayObject, stopAt = null) =>
 export const isResizableCandidate = (displayObject, stopAt = null) =>
   Boolean(displayObject?.constructor?.isResizable) &&
   !isInteractionLocked(displayObject, stopAt);
+
+export const isRotatableCandidate = (displayObject, stopAt = null) =>
+  Boolean(displayObject?.constructor?.isRotatable) &&
+  !isInteractionLocked(displayObject, stopAt);

--- a/src/utils/interaction-locks.test.js
+++ b/src/utils/interaction-locks.test.js
@@ -4,6 +4,7 @@ import {
   isInteractionLocked,
   isLocked,
   isResizableCandidate,
+  isRotatableCandidate,
   isSelectableCandidate,
 } from './interaction-locks';
 
@@ -12,6 +13,7 @@ const createNode = ({
   locked = false,
   isSelectable = false,
   isResizable = false,
+  isRotatable = false,
   children = [],
 } = {}) => {
   const node = {
@@ -21,7 +23,7 @@ const createNode = ({
     parent: null,
   };
 
-  node.constructor = { isSelectable, isResizable };
+  node.constructor = { isSelectable, isResizable, isRotatable };
 
   children.forEach((child) => {
     child.parent = node;
@@ -83,5 +85,17 @@ describe('interaction-locks', () => {
 
     expect(isResizableCandidate(resizable)).toBe(false);
     expect(isResizableCandidate(resizable, lockedParent)).toBe(true);
+  });
+
+  it('should only mark unlocked rotatable objects as rotatable candidates', () => {
+    const rotatable = createNode({ id: 'rotatable', isRotatable: true });
+    const lockedParent = createNode({
+      id: 'locked-parent',
+      locked: true,
+      children: [rotatable],
+    });
+
+    expect(isRotatableCandidate(rotatable)).toBe(false);
+    expect(isRotatableCandidate(rotatable, lockedParent)).toBe(true);
   });
 });

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -1,6 +1,7 @@
 import { Matrix, Point, Rectangle } from 'pixi.js';
 
 const tempMatrix = new Matrix();
+const FRAME_BOUNDS_OPTIONS = { useSizeFallback: true };
 
 // A temporary array of points to be reused across calculations, avoiding frequent object allocation.
 const tempCorners = [new Point(), new Point(), new Point(), new Point()];
@@ -9,11 +10,12 @@ const tempCorners = [new Point(), new Point(), new Point(), new Point()];
  * Calculates the four corners of a DisplayObject in world space.
  *
  * @param {PIXI.DisplayObject} displayObject - The DisplayObject to measure.
+ * @param {{ useSizeFallback?: boolean }} [options]
  * @returns {Array<PIXI.Point>} An array of 4 new Point instances for the world-space corners.
  */
-export const getObjectWorldCorners = (displayObject) => {
+export const getObjectWorldCorners = (displayObject, options = {}) => {
   const corners = tempCorners;
-  const localBounds = getObjectLocalBounds(displayObject);
+  const localBounds = getObjectLocalBounds(displayObject, options);
   if (localBounds.worldCorners) {
     return localBounds.worldCorners;
   }
@@ -38,15 +40,20 @@ export const getObjectWorldCorners = (displayObject) => {
   return corners.map((point) => point.clone());
 };
 
-const getObjectLocalBounds = (displayObject) => {
+export const getObjectFrameWorldCorners = (displayObject) =>
+  getObjectWorldCorners(displayObject, FRAME_BOUNDS_OPTIONS);
+
+const getObjectLocalBounds = (displayObject, options) => {
   const localBounds = displayObject.getLocalBounds();
   if (hasArea(localBounds)) return localBounds;
 
-  const size = normalizeSize(displayObject?.props?.size);
-  if (size) return { x: 0, y: 0, width: size.width, height: size.height };
+  if (options.useSizeFallback) {
+    const size = normalizeSize(displayObject?.props?.size);
+    if (size) return { x: 0, y: 0, width: size.width, height: size.height };
+  }
 
   const childWorldCorners = displayObject.children?.flatMap((child) =>
-    getObjectWorldCorners(child),
+    getObjectWorldCorners(child, options),
   );
   if (childWorldCorners?.length > 0) {
     return {
@@ -85,16 +92,24 @@ const boundsToCorners = (bounds) => [
  *
  * @param {PIXI.DisplayObject} displayObject - The DisplayObject to measure.
  * @param {PIXI.Viewport} viewport - The Viewport to which the coordinates will be relative.
+ * @param {{ useSizeFallback?: boolean }} [options]
  * @returns {Array<PIXI.Point>} An array of 4 new Point instances for the local-space corners relative to the viewport.
  */
-export const getObjectLocalCorners = (displayObject, viewport) => {
+export const getObjectLocalCorners = (
+  displayObject,
+  viewport,
+  options = {},
+) => {
   if (!displayObject || !viewport) {
     return [];
   }
-  return getObjectWorldCorners(displayObject).map((point) =>
+  return getObjectWorldCorners(displayObject, options).map((point) =>
     viewport.toLocal(point),
   );
 };
+
+export const getObjectFrameLocalCorners = (displayObject, viewport) =>
+  getObjectLocalCorners(displayObject, viewport, FRAME_BOUNDS_OPTIONS);
 
 /**
  * Calculates the geometric center (centroid) of an array of points.

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -13,7 +13,10 @@ const tempCorners = [new Point(), new Point(), new Point(), new Point()];
  */
 export const getObjectWorldCorners = (displayObject) => {
   const corners = tempCorners;
-  const localBounds = displayObject.getLocalBounds();
+  const localBounds = getObjectLocalBounds(displayObject);
+  if (localBounds.worldCorners) {
+    return localBounds.worldCorners;
+  }
   const worldTransform = displayObject.getGlobalTransform(tempMatrix, false);
 
   // Set the four corners based on the object's original (local) bounds.
@@ -34,6 +37,47 @@ export const getObjectWorldCorners = (displayObject) => {
   // Return clones to prevent mutation of the globally reused `tempCorners` array.
   return corners.map((point) => point.clone());
 };
+
+const getObjectLocalBounds = (displayObject) => {
+  const localBounds = displayObject.getLocalBounds();
+  if (hasArea(localBounds)) return localBounds;
+
+  const size = normalizeSize(displayObject?.props?.size);
+  if (size) return { x: 0, y: 0, width: size.width, height: size.height };
+
+  const childWorldCorners = displayObject.children?.flatMap((child) =>
+    getObjectWorldCorners(child),
+  );
+  if (childWorldCorners?.length > 0) {
+    return {
+      worldCorners: boundsToCorners(getBoundsFromPoints(childWorldCorners)),
+    };
+  }
+
+  return localBounds;
+};
+
+const hasArea = (bounds) =>
+  (bounds?.width ?? 0) > 0 || (bounds?.height ?? 0) > 0;
+
+const normalizeSize = (size) => {
+  if (typeof size === 'number') return { width: size, height: size };
+  if (
+    Number.isFinite(size?.width) &&
+    Number.isFinite(size?.height) &&
+    (size.width > 0 || size.height > 0)
+  ) {
+    return size;
+  }
+  return null;
+};
+
+const boundsToCorners = (bounds) => [
+  new Point(bounds.x, bounds.y),
+  new Point(bounds.x + bounds.width, bounds.y),
+  new Point(bounds.x + bounds.width, bounds.y + bounds.height),
+  new Point(bounds.x, bounds.y + bounds.height),
+];
 
 /**
  * Calculates the four corners of a DisplayObject and transforms them into the local space of the Viewport.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,5 @@
     "skipLibCheck": true,
     "lib": ["ES2020", "DOM"] // 불필요한 타입 제거,
   },
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "lib": ["ES2020", "DOM"] // 불필요한 타입 제거,
-  }
+  },
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- Adds Figma-style rotation handles to `Transformer`, including center-based rotation, frame-aware rotate cursors, and Item rotation support.
- Updates resize/rotate handle rendering for single rotated selections and unifies gesture history under `transformHistory`.

## Related Issue / Discussion
- Fixes #
- Refs #

## Problem / Goal
- Selection rotation needed to work from invisible corner targets outside the selected frame, matching editor/Figma behavior.
- Rotated single selections needed oriented frames/cursors, while multi-selection should keep an axis-aligned group frame.

## API / Behavior Changes
- Public API changes: `Transformer` adds `rotateHandles` and `transformHistory`; `patchmap.update` supports `rotateOrigin: 'center'`.
- Default value changes: none.
- Breaking changes: yes. `resizeHistory` is removed in favor of `transformHistory` for resize and rotate gestures.

## Migration Guide (if applicable)
- Before:
```js
const transformer = new Transformer({ resizeHistory: true });
```
- After:
```js
const transformer = new Transformer({
  resizeHandles: true,
  rotateHandles: true,
  transformHistory: true,
});
```

## Usage Example (if applicable)
```js
const transformer = new Transformer({ rotateHandles: true });
patchmap.transformer = transformer;
transformer.elements = patchmap.selector('$..[?(@.id=="rect-1")]');

patchmap.update({
  elements: transformer.elements,
  changes: { attrs: { angle: 45 } },
  rotateOrigin: 'center',
});
```

## Validation
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:headless`
- Manual checks performed: `npx vitest --project browser src/tests/Transformer.test.js --browser.headless --run`; targeted rotate/snap tests; Transformer draw perf comparison against `origin/main`.
- Test coverage added/updated: rotation handles, rotate gesture history, angle fallback, center rotation origin, frame-aware resize/rotate cursors, final-angle snapping.

`npm run test:headless -- --run` now passes: 53 files, 815 tests.

## Documentation
- [x] `README.md` updated
- [x] `README_KR.md` updated
- [ ] No documentation update needed

## Release Impact
- [ ] none (internal only)
- [ ] patch (backward-compatible fix/improvement)
- [x] minor (new backward-compatible feature)

## Risks / Follow-up (Optional)
- Risks: UI hit-target and cursor behavior changed around selected frames; consumers relying on `resizeHistory` need to migrate to `transformHistory`.
- Follow-up tasks: none currently known from this PR review.