### PR TITLE
perf(draw): improve initial patch map rendering

### DIFF
--- a/src/display/components/Text.js
+++ b/src/display/components/Text.js
@@ -36,6 +36,11 @@ export class Text extends ComposedText {
   apply(changes, options) {
     super.apply(changes, textSchema, options);
   }
+
+  _applyPlacement(relevantChanges) {
+    if (this.text === '') return;
+    super._applyPlacement(relevantChanges);
+  }
 }
 
 Text.registerHandler(

--- a/src/display/draw.js
+++ b/src/display/draw.js
@@ -1,4 +1,5 @@
 export const draw = (store, data) => {
+  resetElementIndex(store);
   destroyChildren(store.world);
   store.world.apply(
     { type: 'canvas', children: data },
@@ -12,4 +13,9 @@ const destroyChildren = (parent) => {
     child.destroy({ children: true });
   }
   parent.props.children = [];
+};
+
+const resetElementIndex = (store) => {
+  const targetStore = store.world?.store ?? store;
+  targetStore.elementById = new Map();
 };

--- a/src/display/mixins/Animationsizeable.js
+++ b/src/display/mixins/Animationsizeable.js
@@ -5,6 +5,15 @@ import { isUpsideDownScreenAngle } from '../utils/screen-direction';
 import { UPDATE_STAGES } from './constants';
 
 const KEYS = ['animation', 'animationDuration', 'source', 'size', 'margin'];
+const DEFAULT_PLACEMENT_BY_TYPE = {
+  bar: 'bottom',
+  background: 'center',
+  icon: 'center',
+  text: 'center',
+};
+
+const resolveComponentPlacement = (target) =>
+  target.props?.placement ?? DEFAULT_PLACEMENT_BY_TYPE[target.type] ?? 'center';
 
 const reapplyLayoutAfterSizeChange = (target) => {
   if (typeof target._onWorldTransformChanged === 'function') {
@@ -13,7 +22,7 @@ const reapplyLayoutAfterSizeChange = (target) => {
   }
 
   target._applyPlacement?.({
-    placement: target.props?.placement,
+    placement: resolveComponentPlacement(target),
     margin: target.props?.margin,
   });
 };
@@ -65,13 +74,13 @@ export const AnimationSizeable = (superClass) => {
         }
 
         const fromPosition = this._calcPlacementForSize({
-          placement: this.props.placement,
+          placement: resolveComponentPlacement(this),
           margin: this.props.margin,
           width: this.width,
           height: this.height,
         });
         const toPosition = this._calcPlacementForSize({
-          placement: this.props.placement,
+          placement: resolveComponentPlacement(this),
           margin: this.props.margin,
           width: newSize.width,
           height: newSize.height,

--- a/src/display/mixins/Animationsizeable.js
+++ b/src/display/mixins/Animationsizeable.js
@@ -1,19 +1,10 @@
 import { getSizeBatcher } from '../animation/sizeBatchTween';
-import { calcSize } from '../mixins/utils';
+import { calcSize, resolveComponentPlacement } from '../mixins/utils';
 import { hasUprightContentOrientation } from '../utils/content-orientation';
 import { isUpsideDownScreenAngle } from '../utils/screen-direction';
 import { UPDATE_STAGES } from './constants';
 
 const KEYS = ['animation', 'animationDuration', 'source', 'size', 'margin'];
-const DEFAULT_PLACEMENT_BY_TYPE = {
-  bar: 'bottom',
-  background: 'center',
-  icon: 'center',
-  text: 'center',
-};
-
-const resolveComponentPlacement = (target) =>
-  target.props?.placement ?? DEFAULT_PLACEMENT_BY_TYPE[target.type] ?? 'center';
 
 const reapplyLayoutAfterSizeChange = (target) => {
   if (typeof target._onWorldTransformChanged === 'function') {

--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -184,6 +184,8 @@ export const Base = (superClass) => {
       this._applyHandlers(keysToProcess, {
         mergeStrategy,
         refresh,
+        validateSchema,
+        normalize,
         changes: handlerChanges,
       });
 

--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -201,6 +201,33 @@ export const Base = (superClass) => {
       }
     }
 
+    _applyInitialTrusted(changes = {}, options = {}) {
+      if (this.destroyed) return;
+      const initialProps = changes ?? {};
+      const keysToProcess = Object.keys(initialProps);
+      if (keysToProcess.length === 0) return;
+
+      const previousId = this.id;
+      this.props = initialProps;
+
+      if (RAW_SYNC_KEYS.some((key) => Object.hasOwn(initialProps, key))) {
+        const { id, label, attrs } = initialProps;
+        this._applyRaw(
+          { id, label, ...attrs },
+          options.mergeStrategy ?? 'replace',
+        );
+        this._syncStoreElementIndex(previousId);
+      }
+
+      this._applyHandlers(keysToProcess, {
+        ...options,
+        mergeStrategy: options.mergeStrategy ?? 'replace',
+        validateSchema: false,
+        normalize: false,
+        changes: initialProps,
+      });
+    }
+
     _applyHandlers(keysToProcess, options) {
       if (keysToProcess.length === 0) return;
       const handlerMap = this.constructor._handlerMap;

--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -77,6 +77,7 @@ export const Base = (superClass) => {
 
     destroy(options) {
       this.onRender = null;
+      this._removeFromStoreElementIndex();
       super.destroy(options);
     }
 
@@ -176,8 +177,10 @@ export const Base = (superClass) => {
       this.props = validatedProps;
 
       if (RAW_SYNC_KEYS.some((key) => Object.hasOwn(diffProps, key))) {
+        const previousId = this.id;
         const { id, label, attrs } = diffProps;
         this._applyRaw({ id, label, ...attrs }, mergeStrategy);
+        this._syncStoreElementIndex(previousId);
       }
 
       const handlerChanges = options.changes ?? normalizedChanges;
@@ -261,6 +264,30 @@ export const Base = (superClass) => {
 
     _updateProperty(key, value, mergeStrategy) {
       deepMerge(this, { [key]: value }, { mergeStrategy });
+    }
+
+    _syncStoreElementIndex(previousId) {
+      const elementById = this.store?.elementById;
+      if (!elementById) return;
+
+      if (
+        previousId &&
+        previousId !== this.id &&
+        elementById.get(previousId) === this
+      ) {
+        elementById.delete(previousId);
+      }
+      if (this.id) {
+        elementById.set(this.id, this);
+      }
+    }
+
+    _removeFromStoreElementIndex() {
+      const elementById = this.store?.elementById;
+      if (!elementById || !this.id) return;
+      if (elementById.get(this.id) === this) {
+        elementById.delete(this.id);
+      }
     }
   };
 

--- a/src/display/mixins/Cellsable.js
+++ b/src/display/mixins/Cellsable.js
@@ -5,7 +5,7 @@ const KEYS = ['cells', 'inactiveCellStrategy'];
 
 export const Cellsable = (superClass) => {
   const MixedClass = class extends superClass {
-    _applyCells(relevantChanges) {
+    _applyCells(relevantChanges, options = {}) {
       const cells = relevantChanges.cells ?? this.props.cells;
       const { gap, item: itemProps, inactiveCellStrategy } = this.props;
 
@@ -32,16 +32,24 @@ export const Cellsable = (superClass) => {
             };
             const item = newElement('item', this.store);
             this.addChild(item);
-            item.apply({
+            const itemChanges = {
               type: 'item',
               id,
               ...itemProps,
               label,
               attrs,
               show: !isInactive,
+            };
+            item.apply(itemChanges, {
+              ...options,
+              changes: itemChanges,
             });
           } else {
-            existingItem.apply({ label, show: !isInactive });
+            const itemChanges = { label, show: !isInactive };
+            existingItem.apply(itemChanges, {
+              ...options,
+              changes: itemChanges,
+            });
           }
         });
       });

--- a/src/display/mixins/Cellsable.js
+++ b/src/display/mixins/Cellsable.js
@@ -42,10 +42,7 @@ export const Cellsable = (superClass) => {
               attrs,
               show: !isInactive,
             };
-            item.apply(itemChanges, {
-              ...options,
-              changes: itemChanges,
-            });
+            applyInitialCellItem(item, itemChanges, options);
           } else {
             const itemChanges = { label, show: !isInactive };
             existingItem.apply(itemChanges, {
@@ -72,4 +69,22 @@ export const Cellsable = (superClass) => {
     UPDATE_STAGES.CHILD_RENDER,
   );
   return MixedClass;
+};
+
+const canUseInitialFastPath = (options) =>
+  options.mergeStrategy === 'replace' &&
+  options.validateSchema === false &&
+  options.normalize === false;
+
+const applyInitialCellItem = (item, itemChanges, options) => {
+  const applyOptions = {
+    ...options,
+    changes: itemChanges,
+  };
+  if (canUseInitialFastPath(options)) {
+    item._applyInitialTrusted(itemChanges, applyOptions);
+    return;
+  }
+
+  item.apply(itemChanges, applyOptions);
 };

--- a/src/display/mixins/Cellsable.js
+++ b/src/display/mixins/Cellsable.js
@@ -13,6 +13,8 @@ export const Cellsable = (superClass) => {
       const childrenMap = new Map(
         this.children.map((child) => [child.id, child]),
       );
+      this._cellsApplyCreatedAllGridItems =
+        options.mergeStrategy === 'replace' && childrenMap.size === 0;
 
       cells.forEach((row, rowIndex) => {
         row.forEach((col, colIndex) => {

--- a/src/display/mixins/Childrenable.js
+++ b/src/display/mixins/Childrenable.js
@@ -10,11 +10,10 @@ const KEYS = ['children'];
 export const Childrenable = (superClass) => {
   const MixedClass = class extends superClass {
     _applyChildren(relevantChanges, options = {}) {
-      const childOptions = {
-        ...options,
-        validateSchema: false,
-        normalize: false,
-      };
+      const childOptions =
+        options.validateSchema === false
+          ? { ...options, validateSchema: false, normalize: false }
+          : options;
       let childrenChanges = options.refresh
         ? relevantChanges?.children
         : (options.changes?.children ?? relevantChanges?.children);

--- a/src/display/mixins/Childrenable.js
+++ b/src/display/mixins/Childrenable.js
@@ -25,6 +25,7 @@ export const Childrenable = (superClass) => {
         elements,
         childrenChanges,
         mapDataSchema,
+        childOptions,
       );
 
       for (const childChange of childrenChanges) {

--- a/src/display/mixins/Childrenable.js
+++ b/src/display/mixins/Childrenable.js
@@ -30,6 +30,7 @@ export const Childrenable = (superClass) => {
       for (const childChange of childrenChanges) {
         const idx = findIndexByPriority(elements, childChange);
         let element = null;
+        let isNewElement = false;
 
         if (idx !== -1) {
           element = elements[idx];
@@ -40,8 +41,9 @@ export const Childrenable = (superClass) => {
         } else {
           element = newElement(childChange.type, this.store);
           this.addChild(element);
+          isNewElement = true;
         }
-        element.apply(childChange, { ...childOptions, changes: childChange });
+        applyInitialChild(element, childChange, childOptions, isNewElement);
       }
 
       if (options.mergeStrategy === 'replace') {
@@ -73,4 +75,24 @@ export const Childrenable = (superClass) => {
     UPDATE_STAGES.CHILD_RENDER,
   );
   return MixedClass;
+};
+
+const canUseInitialFastPath = (options) =>
+  options.mergeStrategy === 'replace' &&
+  options.validateSchema === false &&
+  options.normalize === false;
+
+const applyInitialChild = (
+  element,
+  childChange,
+  childOptions,
+  isNewElement,
+) => {
+  const applyOptions = { ...childOptions, changes: childChange };
+  if (isNewElement && canUseInitialFastPath(childOptions)) {
+    element._applyInitialTrusted(childChange, applyOptions);
+    return;
+  }
+
+  element.apply(childChange, applyOptions);
 };

--- a/src/display/mixins/Componentsable.js
+++ b/src/display/mixins/Componentsable.js
@@ -11,11 +11,10 @@ const ORIENTATION_KEYS = ['contentOrientation'];
 export const Componentsable = (superClass) => {
   const MixedClass = class extends superClass {
     _applyComponents(relevantChanges, options = {}) {
-      const childOptions = {
-        ...options,
-        validateSchema: false,
-        normalize: false,
-      };
+      const childOptions =
+        options.validateSchema === false
+          ? { ...options, validateSchema: false, normalize: false }
+          : options;
       let componentsChanges = options.refresh
         ? relevantChanges?.components
         : (options.changes?.components ?? relevantChanges?.components);

--- a/src/display/mixins/Componentsable.js
+++ b/src/display/mixins/Componentsable.js
@@ -31,6 +31,7 @@ export const Componentsable = (superClass) => {
       for (const componentChange of componentsChanges) {
         const idx = findIndexByPriority(components, componentChange);
         let component = null;
+        let isNewComponent = false;
 
         if (idx !== -1) {
           component = components[idx];
@@ -41,12 +42,15 @@ export const Componentsable = (superClass) => {
         } else {
           component = newComponent(componentChange.type, this.store);
           this.addChild(component);
+          isNewComponent = true;
         }
         const applyChanges = { type: componentChange.type, ...componentChange };
-        component.apply(applyChanges, {
-          ...childOptions,
-          changes: applyChanges,
-        });
+        applyInitialComponent(
+          component,
+          applyChanges,
+          childOptions,
+          isNewComponent,
+        );
       }
 
       if (options.mergeStrategy === 'replace') {
@@ -91,4 +95,27 @@ export const Componentsable = (superClass) => {
     UPDATE_STAGES.WORLD_TRANSFORM,
   );
   return MixedClass;
+};
+
+const canUseInitialFastPath = (options) =>
+  options.mergeStrategy === 'replace' &&
+  options.validateSchema === false &&
+  options.normalize === false;
+
+const applyInitialComponent = (
+  component,
+  applyChanges,
+  childOptions,
+  isNewComponent,
+) => {
+  const applyOptions = {
+    ...childOptions,
+    changes: applyChanges,
+  };
+  if (isNewComponent && canUseInitialFastPath(childOptions)) {
+    component._applyInitialTrusted(applyChanges, applyOptions);
+    return;
+  }
+
+  component.apply(applyChanges, applyOptions);
 };

--- a/src/display/mixins/Componentsable.js
+++ b/src/display/mixins/Componentsable.js
@@ -39,6 +39,8 @@ export const Componentsable = (superClass) => {
           if (options.mergeStrategy === 'replace') {
             this.addChild(component);
           }
+        } else if (componentChange.show === false) {
+          continue;
         } else {
           component = newComponent(componentChange.type, this.store);
           this.addChild(component);

--- a/src/display/mixins/Componentsable.js
+++ b/src/display/mixins/Componentsable.js
@@ -26,6 +26,7 @@ export const Componentsable = (superClass) => {
         components,
         componentsChanges,
         componentArraySchema,
+        childOptions,
       );
 
       for (const componentChange of componentsChanges) {

--- a/src/display/mixins/Itemable.js
+++ b/src/display/mixins/Itemable.js
@@ -5,6 +5,14 @@ const KEYS = ['item', 'gap'];
 export const Itemable = (superClass) => {
   const MixedClass = class extends superClass {
     _applyItem(relevantChanges, options) {
+      if (
+        options?.mergeStrategy === 'replace' &&
+        this._cellsApplyCreatedAllGridItems
+      ) {
+        this._cellsApplyCreatedAllGridItems = false;
+        return;
+      }
+
       const { item: itemProps, gap } = relevantChanges;
 
       const gridIdPrefix = `${this.id}.`;

--- a/src/display/mixins/Itemsizeable.js
+++ b/src/display/mixins/Itemsizeable.js
@@ -5,6 +5,13 @@ const KEYS = ['size', 'padding'];
 export const ItemSizeable = (superClass) => {
   const MixedClass = class extends superClass {
     _applyItemSize(_relevantChanges, options = {}) {
+      if (
+        options.mergeStrategy === 'replace' &&
+        Array.isArray(options.changes?.components)
+      ) {
+        return;
+      }
+
       for (const child of this.children) {
         child.apply(undefined, {
           ...options,

--- a/src/display/mixins/Itemsizeable.js
+++ b/src/display/mixins/Itemsizeable.js
@@ -4,9 +4,13 @@ const KEYS = ['size', 'padding'];
 
 export const ItemSizeable = (superClass) => {
   const MixedClass = class extends superClass {
-    _applyItemSize() {
+    _applyItemSize(_relevantChanges, options = {}) {
       for (const child of this.children) {
-        child.apply(undefined, { refresh: true });
+        child.apply(undefined, {
+          ...options,
+          changes: undefined,
+          refresh: true,
+        });
       }
     }
   };

--- a/src/display/mixins/Placementable.js
+++ b/src/display/mixins/Placementable.js
@@ -4,21 +4,9 @@ import {
 } from '../utils/placement-frame';
 import { resolvePlacementOffset } from '../utils/placement-offset';
 import { UPDATE_STAGES } from './constants';
-import { getLayoutContext } from './utils';
+import { getLayoutContext, resolveComponentPlacement } from './utils';
 
 const KEYS = ['placement', 'margin'];
-const DEFAULT_PLACEMENT_BY_TYPE = {
-  bar: 'bottom',
-  background: 'center',
-  icon: 'center',
-  text: 'center',
-};
-
-const resolveComponentPlacement = (component, placement) =>
-  placement ??
-  component.props?.placement ??
-  DEFAULT_PLACEMENT_BY_TYPE[component.type] ??
-  'center';
 
 const calcEffectiveSize = (component, width, height) => {
   const bounds = component.getLocalBounds();

--- a/src/display/mixins/Placementable.js
+++ b/src/display/mixins/Placementable.js
@@ -7,6 +7,18 @@ import { UPDATE_STAGES } from './constants';
 import { getLayoutContext } from './utils';
 
 const KEYS = ['placement', 'margin'];
+const DEFAULT_PLACEMENT_BY_TYPE = {
+  bar: 'bottom',
+  background: 'center',
+  icon: 'center',
+  text: 'center',
+};
+
+const resolveComponentPlacement = (component, placement) =>
+  placement ??
+  component.props?.placement ??
+  DEFAULT_PLACEMENT_BY_TYPE[component.type] ??
+  'center';
 
 const calcEffectiveSize = (component, width, height) => {
   const bounds = component.getLocalBounds();
@@ -24,7 +36,7 @@ export const Placementable = (superClass) => {
     _applyPlacement(relevantChanges) {
       const { placement, margin } = relevantChanges;
       const { x, y } = this._calcPlacementForSize({
-        placement,
+        placement: resolveComponentPlacement(this, placement),
         margin,
         width: this.width,
         height: this.height,
@@ -34,7 +46,11 @@ export const Placementable = (superClass) => {
 
     _calcPlacementForSize({ placement, margin, width, height }) {
       const layoutContext = getLayoutContext(this);
-      const layoutFrame = resolvePlacementFrame(this, placement, margin);
+      const layoutFrame = resolvePlacementFrame(
+        this,
+        resolveComponentPlacement(this, placement),
+        margin,
+      );
       const effectiveSize = calcEffectiveSize(this, width, height);
       const point = calcPlacementPoint(
         layoutContext,

--- a/src/display/mixins/TextLayoutable.js
+++ b/src/display/mixins/TextLayoutable.js
@@ -27,7 +27,11 @@ export const TextLayoutable = (superClass) => {
       // 3. Font Size: Auto
       if (style?.fontSize === 'auto') {
         const range = style.autoFont ?? DEFAULT_AUTO_FONT_RANGE;
-        this._setAutoFontSize(visual, bounds, range);
+        if (visual.text === '') {
+          visual.style.fontSize = range.max;
+        } else {
+          this._setAutoFontSize(visual, bounds, range);
+        }
       }
 
       // 4. Overflow Handling

--- a/src/display/mixins/linksable.js
+++ b/src/display/mixins/linksable.js
@@ -46,7 +46,7 @@ export const Linksable = (superClass) => {
 
     _applyLinks(relevantChanges) {
       const { links } = relevantChanges;
-      this.linkedObjects = uniqueLinked(this.store.viewport, links);
+      this.linkedObjects = uniqueLinked(this.store, links);
       this._renderDirty = true;
     }
   };
@@ -74,8 +74,32 @@ const isAncestor = (parent, target) => {
   return false;
 };
 
-const uniqueLinked = (viewport, links) => {
+const uniqueLinked = (store, links) => {
   const uniqueIds = new Set(links.flatMap((link) => Object.values(link)));
+  const { elementById, viewport } = store;
+  if (elementById) {
+    const objects = [];
+    const missingIds = new Set();
+    for (const id of uniqueIds) {
+      const object = elementById.get(id);
+      if (object && !object.destroyed) {
+        objects.push(object);
+      } else {
+        missingIds.add(id);
+      }
+    }
+    if (missingIds.size === 0) {
+      return Object.fromEntries(objects.map((obj) => [obj.id, obj]));
+    }
+
+    const missingObjects = collectCandidates(viewport, (child) =>
+      missingIds.has(child.id),
+    );
+    return Object.fromEntries(
+      [...objects, ...missingObjects].map((obj) => [obj.id, obj]),
+    );
+  }
+
   const objects = collectCandidates(viewport, (child) =>
     uniqueIds.has(child.id),
   );

--- a/src/display/mixins/utils.js
+++ b/src/display/mixins/utils.js
@@ -40,8 +40,23 @@ const roundToPrecision = (value, precision = 6) => {
   return Math.round((value + Number.EPSILON) * factor) / factor;
 };
 
+const DEFAULT_COMPONENT_SIZE = {
+  width: { value: 100, unit: '%' },
+  height: { value: 100, unit: '%' },
+};
+
 export const calcSize = (component, { source, size }) => {
   const { contentWidth, contentHeight } = getLayoutContext(component);
+  const resolvedSize = {
+    width:
+      size?.width ??
+      component.props?.size?.width ??
+      DEFAULT_COMPONENT_SIZE.width,
+    height:
+      size?.height ??
+      component.props?.size?.height ??
+      DEFAULT_COMPONENT_SIZE.height,
+  };
 
   const borderWidth =
     typeof source === 'object' ? (source?.borderWidth ?? 0) : 0;
@@ -49,22 +64,28 @@ export const calcSize = (component, { source, size }) => {
   let finalWidth = null;
   let finalHeight = null;
 
-  if (typeof size.width === 'string' && size.width.startsWith('calc')) {
-    finalWidth = parseCalcExpression(size.width, contentWidth);
+  if (
+    typeof resolvedSize.width === 'string' &&
+    resolvedSize.width.startsWith('calc')
+  ) {
+    finalWidth = parseCalcExpression(resolvedSize.width, contentWidth);
   } else {
     finalWidth =
-      size.width.unit === '%'
-        ? contentWidth * (size.width.value / 100)
-        : size.width.value;
+      resolvedSize.width.unit === '%'
+        ? contentWidth * (resolvedSize.width.value / 100)
+        : resolvedSize.width.value;
   }
 
-  if (typeof size.height === 'string' && size.height.startsWith('calc')) {
-    finalHeight = parseCalcExpression(size.height, contentHeight);
+  if (
+    typeof resolvedSize.height === 'string' &&
+    resolvedSize.height.startsWith('calc')
+  ) {
+    finalHeight = parseCalcExpression(resolvedSize.height, contentHeight);
   } else {
     finalHeight =
-      size.height.unit === '%'
-        ? contentHeight * (size.height.value / 100)
-        : size.height.value;
+      resolvedSize.height.unit === '%'
+        ? contentHeight * (resolvedSize.height.value / 100)
+        : resolvedSize.height.value;
   }
 
   return {

--- a/src/display/mixins/utils.js
+++ b/src/display/mixins/utils.js
@@ -55,11 +55,36 @@ const normalizePxOrPercentValue = (value) => {
   if (typeof value === 'number') {
     return { value, unit: 'px' };
   }
-  if (typeof value === 'string' && value.endsWith('%')) {
-    return { value: Number.parseFloat(value.slice(0, -1)), unit: '%' };
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim();
+    if (trimmedValue.endsWith('%')) {
+      return { value: Number.parseFloat(trimmedValue), unit: '%' };
+    }
+    if (trimmedValue.endsWith('px')) {
+      return { value: Number.parseFloat(trimmedValue), unit: 'px' };
+    }
+    if (!trimmedValue.startsWith('calc')) {
+      const numericValue = Number(trimmedValue);
+      if (!Number.isNaN(numericValue) && trimmedValue !== '') {
+        return { value: numericValue, unit: 'px' };
+      }
+    }
   }
   return value;
 };
+
+export const DEFAULT_PLACEMENT_BY_TYPE = {
+  bar: 'bottom',
+  background: 'center',
+  icon: 'center',
+  text: 'center',
+};
+
+export const resolveComponentPlacement = (component, placement) =>
+  placement ??
+  component.props?.placement ??
+  DEFAULT_PLACEMENT_BY_TYPE[component.type] ??
+  'center';
 
 const normalizeComponentSize = (size) => {
   if (

--- a/src/display/mixins/utils.js
+++ b/src/display/mixins/utils.js
@@ -86,9 +86,15 @@ export const mixins = (baseClass, ...mixins) => {
  * @param {Array<object>} currentElements - Array of current child elements (components) in the DOM
  * @param {Array<object>} changes - Array of change data to apply
  * @param {import('zod').ZodSchema} schema - Zod schema to use for validation
+ * @param {{ validateSchema?: boolean }} options - Validation controls
  * @returns {Array<object>} The changes array, with validated and default-filled data
  */
-export const validateAndPrepareChanges = (currentElements, changes, schema) => {
+export const validateAndPrepareChanges = (
+  currentElements,
+  changes,
+  schema,
+  options = {},
+) => {
   const preparedChanges = [...changes];
   const used = new Set();
   const newElementDefs = [];
@@ -103,6 +109,10 @@ export const validateAndPrepareChanges = (currentElements, changes, schema) => {
       used.add(foundIndex);
     }
   });
+
+  if (options.validateSchema === false) {
+    return preparedChanges;
+  }
 
   // Perform batch validation only if there are new elements to be added
   if (newElementDefs.length > 0) {

--- a/src/display/mixins/utils.js
+++ b/src/display/mixins/utils.js
@@ -45,18 +45,55 @@ const DEFAULT_COMPONENT_SIZE = {
   height: { value: 100, unit: '%' },
 };
 
+const isPxOrPercentValue = (value) =>
+  value &&
+  typeof value === 'object' &&
+  Object.hasOwn(value, 'value') &&
+  Object.hasOwn(value, 'unit');
+
+const normalizePxOrPercentValue = (value) => {
+  if (typeof value === 'number') {
+    return { value, unit: 'px' };
+  }
+  if (typeof value === 'string' && value.endsWith('%')) {
+    return { value: Number.parseFloat(value.slice(0, -1)), unit: '%' };
+  }
+  return value;
+};
+
+const normalizeComponentSize = (size) => {
+  if (
+    typeof size === 'number' ||
+    typeof size === 'string' ||
+    isPxOrPercentValue(size)
+  ) {
+    const normalized = normalizePxOrPercentValue(size);
+    return { width: normalized, height: normalized };
+  }
+  if (!size || typeof size !== 'object') return null;
+
+  if (isPxOrPercentValue(size.width) && isPxOrPercentValue(size.height)) {
+    return size;
+  }
+
+  return {
+    width: normalizePxOrPercentValue(size.width),
+    height: normalizePxOrPercentValue(size.height),
+  };
+};
+
 export const calcSize = (component, { source, size }) => {
   const { contentWidth, contentHeight } = getLayoutContext(component);
-  const resolvedSize = {
-    width:
-      size?.width ??
-      component.props?.size?.width ??
-      DEFAULT_COMPONENT_SIZE.width,
-    height:
-      size?.height ??
-      component.props?.size?.height ??
-      DEFAULT_COMPONENT_SIZE.height,
-  };
+  const currentPropsSize = component.props?.size;
+  const hasNormalizedRequestedSize =
+    isPxOrPercentValue(size?.width) && isPxOrPercentValue(size?.height);
+  const hasNormalizedCurrentSize =
+    isPxOrPercentValue(currentPropsSize?.width) &&
+    isPxOrPercentValue(currentPropsSize?.height);
+  const resolvedSize =
+    hasNormalizedRequestedSize || (size == null && hasNormalizedCurrentSize)
+      ? (size ?? currentPropsSize)
+      : resolveComponentSize(size, currentPropsSize);
 
   const borderWidth =
     typeof source === 'object' ? (source?.borderWidth ?? 0) : 0;
@@ -92,6 +129,25 @@ export const calcSize = (component, { source, size }) => {
     width: roundToPrecision(finalWidth + borderWidth),
     height: roundToPrecision(finalHeight + borderWidth),
     borderWidth: borderWidth,
+  };
+};
+
+const resolveComponentSize = (size, currentPropsSize) => {
+  const requestedSize = size == null ? null : normalizeComponentSize(size);
+  const currentSize =
+    requestedSize?.width && requestedSize?.height
+      ? null
+      : normalizeComponentSize(currentPropsSize);
+
+  return {
+    width:
+      requestedSize?.width ??
+      currentSize?.width ??
+      DEFAULT_COMPONENT_SIZE.width,
+    height:
+      requestedSize?.height ??
+      currentSize?.height ??
+      DEFAULT_COMPONENT_SIZE.height,
   };
 };
 

--- a/src/display/mixins/utils.test.js
+++ b/src/display/mixins/utils.test.js
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { calcSize, parseCalcExpression } from './utils';
+import { z } from 'zod';
+import {
+  calcSize,
+  parseCalcExpression,
+  validateAndPrepareChanges,
+} from './utils';
 
 describe('parseCalcExpression', () => {
   const parentDimension = 200;
@@ -53,12 +58,12 @@ describe('parseCalcExpression', () => {
     },
   ];
 
-  it.each(testCases)(
-    'should correctly parse $name',
-    ({ expression, expected }) => {
-      expect(parseCalcExpression(expression, parentDimension)).toBe(expected);
-    },
-  );
+  it.each(testCases)('should correctly parse $name', ({
+    expression,
+    expected,
+  }) => {
+    expect(parseCalcExpression(expression, parentDimension)).toBe(expected);
+  });
 });
 
 describe('calcSize', () => {
@@ -182,15 +187,38 @@ describe('calcSize', () => {
     },
   ];
 
-  it.each(testCases)(
-    'should calculate size correctly $name',
-    ({ props, respectsPadding, parent = mockParent, expected }) => {
-      const mockComponent = {
-        constructor: { respectsPadding },
-        parent,
-      };
-      const result = calcSize(mockComponent, props);
-      expect(result).toEqual(expected);
-    },
-  );
+  it.each(testCases)('should calculate size correctly $name', ({
+    props,
+    respectsPadding,
+    parent = mockParent,
+    expected,
+  }) => {
+    const mockComponent = {
+      constructor: { respectsPadding },
+      parent,
+    };
+    const result = calcSize(mockComponent, props);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('validateAndPrepareChanges', () => {
+  it('skips new element validation when validateSchema is false', () => {
+    const changes = [{ type: 'icon' }];
+    const schema = z.array(
+      z.object({
+        type: z.string(),
+        source: z.string().default('wifi'),
+      }),
+    );
+
+    expect(
+      validateAndPrepareChanges([], changes, schema, {
+        validateSchema: false,
+      }),
+    ).toEqual([{ type: 'icon' }]);
+    expect(validateAndPrepareChanges([], changes, schema)).toEqual([
+      { type: 'icon', source: 'wifi' },
+    ]);
+  });
 });

--- a/src/display/mixins/utils.test.js
+++ b/src/display/mixins/utils.test.js
@@ -176,6 +176,15 @@ describe('calcSize', () => {
       expected: { width: 180, height: 50, borderWidth: 10 },
     },
     {
+      name: 'with numeric string values',
+      props: {
+        source: {},
+        size: { width: '100', height: '50px' },
+      },
+      respectsPadding: true,
+      expected: { width: 100, height: 50, borderWidth: 0 },
+    },
+    {
       name: 'with calc() expressions and borderWidth',
       props: {
         source: { borderWidth: 2 },

--- a/src/tests/perf/draw-data.json
+++ b/src/tests/perf/draw-data.json
@@ -1,0 +1,11271 @@
+[
+  {
+    "type": "group",
+    "id": "fixture.playground",
+    "label": "element and component coverage",
+    "attrs": {
+      "x": 80,
+      "y": 80,
+      "display": "fixture"
+    },
+    "children": [
+      {
+        "type": "item",
+        "id": "sample.item.0",
+        "label": "sample-0",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": 6,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.0.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.0.bar.primary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "35%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.0.bar.secondary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.0.text",
+            "show": true,
+            "text": "0\nW",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.0.icon",
+            "show": false,
+            "source": "loading",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.1",
+        "label": "sample-1",
+        "attrs": {
+          "x": 72,
+          "y": 0,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.1.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.1.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "45%"
+            },
+            "placement": "top",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "#22c55e",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.1.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.1.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.1.icon",
+            "show": true,
+            "source": "warning",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "#f59e0b"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.2",
+        "label": "sample-2",
+        "attrs": {
+          "x": 144,
+          "y": 0,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.2.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.2.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "55%"
+            },
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.2.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.2.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.2.icon",
+            "show": true,
+            "source": "wifi",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.3",
+        "label": "sample-3",
+        "attrs": {
+          "x": 216,
+          "y": 0,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": 6,
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.3.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.3.bar.primary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "65%"
+            },
+            "placement": "right",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.3.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.3.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.3.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.4",
+        "label": "sample-4",
+        "attrs": {
+          "x": 288,
+          "y": 0,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.4.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.4.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "75%"
+            },
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.4.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.4.text",
+            "show": true,
+            "text": "4\nW",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.4.icon",
+            "show": false,
+            "source": "loading",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.5",
+        "label": "sample-5",
+        "attrs": {
+          "x": 360,
+          "y": 0,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.5.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.5.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "85%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.5.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.5.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.5.icon",
+            "show": true,
+            "source": "warning",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "#f59e0b"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.6",
+        "label": "sample-6",
+        "attrs": {
+          "x": 432,
+          "y": 0,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": 6,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.6.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.6.bar.primary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "35%"
+            },
+            "placement": "top",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "#22c55e",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.6.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.6.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.6.icon",
+            "show": true,
+            "source": "wifi",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.7",
+        "label": "sample-7",
+        "attrs": {
+          "x": 504,
+          "y": 0,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.7.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.7.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "45%"
+            },
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.7.bar.secondary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.7.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.7.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.8",
+        "label": "sample-8",
+        "attrs": {
+          "x": 0,
+          "y": 112,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.8.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.8.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "55%"
+            },
+            "placement": "right",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.8.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.8.text",
+            "show": true,
+            "text": "8\nW",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.8.icon",
+            "show": false,
+            "source": "loading",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.9",
+        "label": "sample-9",
+        "attrs": {
+          "x": 72,
+          "y": 112,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": 6,
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.9.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.9.bar.primary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "65%"
+            },
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.9.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.9.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.9.icon",
+            "show": true,
+            "source": "warning",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "#f59e0b"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.10",
+        "label": "sample-10",
+        "attrs": {
+          "x": 144,
+          "y": 112,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.10.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.10.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "75%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.10.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.10.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.10.icon",
+            "show": true,
+            "source": "wifi",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.11",
+        "label": "sample-11",
+        "attrs": {
+          "x": 216,
+          "y": 112,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.11.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.11.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "85%"
+            },
+            "placement": "top",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "#22c55e",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.11.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.11.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.11.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.12",
+        "label": "sample-12",
+        "attrs": {
+          "x": 288,
+          "y": 112,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": 6,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.12.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.12.bar.primary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "35%"
+            },
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.12.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.12.text",
+            "show": true,
+            "text": "12\nW",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.12.icon",
+            "show": false,
+            "source": "loading",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.13",
+        "label": "sample-13",
+        "attrs": {
+          "x": 360,
+          "y": 112,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.13.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.13.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "45%"
+            },
+            "placement": "right",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.13.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.13.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.13.icon",
+            "show": true,
+            "source": "warning",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "#f59e0b"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.14",
+        "label": "sample-14",
+        "attrs": {
+          "x": 432,
+          "y": 112,
+          "display": "sample"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": {
+          "top": 4,
+          "right": 6,
+          "bottom": 8,
+          "left": 6
+        },
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.14.bg",
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.14.bar.primary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "55%"
+            },
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.14.bar.secondary",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.14.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.14.icon",
+            "show": true,
+            "source": "wifi",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "sample.item.15",
+        "label": "sample-15",
+        "attrs": {
+          "x": 504,
+          "y": 112,
+          "display": "device"
+        },
+        "size": {
+          "width": 58,
+          "height": 88
+        },
+        "padding": 6,
+        "contentOrientation": "follow-item",
+        "components": [
+          {
+            "type": "background",
+            "id": "sample.item.15.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#f8fafc",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.15.bar.primary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "65%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "bar",
+            "id": "sample.item.15.bar.secondary",
+            "show": false,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "100%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          },
+          {
+            "type": "text",
+            "id": "sample.item.15.text",
+            "show": false,
+            "text": "",
+            "placement": "center",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "icon",
+            "id": "sample.item.15.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "center",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          }
+        ]
+      },
+      {
+        "type": "rect",
+        "id": "sample.rect.solid",
+        "label": "solid rect",
+        "attrs": {
+          "x": 0,
+          "y": 270
+        },
+        "size": {
+          "width": 180,
+          "height": 72
+        },
+        "fill": "#0f172a",
+        "radius": 12
+      },
+      {
+        "type": "rect",
+        "id": "sample.rect.stroke",
+        "label": "stroke rect",
+        "attrs": {
+          "x": 210,
+          "y": 270
+        },
+        "size": {
+          "width": 180,
+          "height": 72
+        },
+        "fill": "#f8fafc",
+        "stroke": {
+          "color": "#ef4444",
+          "width": 3
+        },
+        "radius": {
+          "topLeft": 4,
+          "topRight": 12,
+          "bottomRight": 4,
+          "bottomLeft": 12
+        }
+      },
+      {
+        "type": "text",
+        "id": "sample.text.title",
+        "label": "text title",
+        "attrs": {
+          "x": 420,
+          "y": 270
+        },
+        "text": "Patch map benchmark text",
+        "size": {
+          "width": 260,
+          "height": 80
+        },
+        "style": {
+          "fontSize": 18,
+          "fill": "#111827",
+          "fontWeight": "700",
+          "wordWrap": true,
+          "lineHeight": 22
+        }
+      },
+      {
+        "type": "image",
+        "id": "sample.image.loading",
+        "label": "asset image",
+        "attrs": {
+          "x": 720,
+          "y": 270
+        },
+        "source": "loading",
+        "size": {
+          "width": 64,
+          "height": 64
+        }
+      },
+      {
+        "type": "relations",
+        "id": "sample.relations.items",
+        "label": "sample links",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "edge"
+        },
+        "links": [
+          {
+            "source": "sample.item.0",
+            "target": "sample.item.1"
+          },
+          {
+            "source": "sample.item.1",
+            "target": "sample.item.2"
+          },
+          {
+            "source": "sample.item.8",
+            "target": "sample.item.9"
+          }
+        ],
+        "style": {
+          "color": "#64748b",
+          "width": 2,
+          "cap": "round",
+          "join": "round"
+        }
+      }
+    ]
+  },
+  {
+    "type": "group",
+    "id": "fixture.inverters",
+    "label": "inverters",
+    "attrs": {
+      "x": 80,
+      "y": 500
+    },
+    "children": [
+      {
+        "type": "item",
+        "id": "inverter.0",
+        "label": "INV-01",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 120
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.0.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.0.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.0.text",
+            "show": true,
+            "text": "INV\n1",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.0.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "45%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.1",
+        "label": "INV-02",
+        "attrs": {
+          "x": 140,
+          "y": 0,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 130
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.1.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.1.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.1.text",
+            "show": true,
+            "text": "INV\n2",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.1.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "54%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.2",
+        "label": "INV-03",
+        "attrs": {
+          "x": 280,
+          "y": 0,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 140
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.2.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.2.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.2.text",
+            "show": true,
+            "text": "INV\n3",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.2.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "63%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.3",
+        "label": "INV-04",
+        "attrs": {
+          "x": 420,
+          "y": 0,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 150
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.3.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.3.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.3.text",
+            "show": true,
+            "text": "INV\n4",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.3.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "72%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.4",
+        "label": "INV-05",
+        "attrs": {
+          "x": 560,
+          "y": 0,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 160
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.4.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.4.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.4.text",
+            "show": true,
+            "text": "INV\n5",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.4.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "81%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.5",
+        "label": "INV-06",
+        "attrs": {
+          "x": 700,
+          "y": 0,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 170
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.5.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.5.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.5.text",
+            "show": true,
+            "text": "INV\n6",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.5.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "45%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.6",
+        "label": "INV-07",
+        "attrs": {
+          "x": 840,
+          "y": 0,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 180
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.6.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.6.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.6.text",
+            "show": true,
+            "text": "INV\n7",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.6.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "54%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.7",
+        "label": "INV-08",
+        "attrs": {
+          "x": 0,
+          "y": 130,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 190
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.7.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.7.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.7.text",
+            "show": true,
+            "text": "INV\n8",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.7.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "63%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.8",
+        "label": "INV-09",
+        "attrs": {
+          "x": 140,
+          "y": 130,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 200
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.8.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.8.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.8.text",
+            "show": true,
+            "text": "INV\n9",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.8.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "72%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.9",
+        "label": "INV-10",
+        "attrs": {
+          "x": 280,
+          "y": 130,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 210
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.9.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.9.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.9.text",
+            "show": true,
+            "text": "INV\n10",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.9.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "81%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.10",
+        "label": "INV-11",
+        "attrs": {
+          "x": 420,
+          "y": 130,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 220
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.10.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.10.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.10.text",
+            "show": true,
+            "text": "INV\n11",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.10.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "45%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.11",
+        "label": "INV-12",
+        "attrs": {
+          "x": 560,
+          "y": 130,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 230
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.11.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.11.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.11.text",
+            "show": true,
+            "text": "INV\n12",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.11.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "54%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.12",
+        "label": "INV-13",
+        "attrs": {
+          "x": 700,
+          "y": 130,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 240
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.12.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.12.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.12.text",
+            "show": true,
+            "text": "INV\n13",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.12.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "63%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      },
+      {
+        "type": "item",
+        "id": "inverter.13",
+        "label": "INV-14",
+        "attrs": {
+          "x": 840,
+          "y": 130,
+          "display": "inverter",
+          "metadata": {
+            "capacityKw": 250
+          }
+        },
+        "size": {
+          "width": 106,
+          "height": 88
+        },
+        "padding": 8,
+        "contentOrientation": "upright",
+        "components": [
+          {
+            "type": "background",
+            "id": "inverter.13.bg",
+            "source": {
+              "type": "rect",
+              "fill": "#e0f2fe",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 6
+            },
+            "size": {
+              "width": {
+                "value": 100,
+                "unit": "%"
+              },
+              "height": {
+                "value": 100,
+                "unit": "%"
+              }
+            },
+            "tint": 16777215
+          },
+          {
+            "type": "icon",
+            "id": "inverter.13.icon",
+            "show": true,
+            "source": "inverter",
+            "size": 20,
+            "placement": "left",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "black"
+          },
+          {
+            "type": "text",
+            "id": "inverter.13.text",
+            "show": true,
+            "text": "INV\n14",
+            "placement": "right",
+            "margin": {
+              "top": 4,
+              "right": 4,
+              "bottom": 4,
+              "left": 4
+            },
+            "tint": "white",
+            "split": 0,
+            "style": {
+              "fontWeight": "600",
+              "fontSize": "auto",
+              "autoFont": {
+                "min": 8,
+                "max": 14
+              },
+              "align": "center",
+              "fill": "white",
+              "breakWords": true,
+              "wordWrapWidth": "auto",
+              "overflow": "ellipsis"
+            }
+          },
+          {
+            "type": "bar",
+            "id": "inverter.13.bar",
+            "show": true,
+            "source": {
+              "type": "rect",
+              "fill": "white",
+              "borderColor": "primary.dark",
+              "borderWidth": 2,
+              "radius": 3
+            },
+            "size": {
+              "width": "100%",
+              "height": "72%"
+            },
+            "placement": "bottom",
+            "margin": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 0
+            },
+            "tint": "primary.default",
+            "animation": false,
+            "animationDuration": 200
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.0",
+    "label": "Panel Group 1",
+    "attrs": {
+      "x": 80,
+      "y": 780,
+      "angle": 0,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.0"
+      }
+    },
+    "cells": [
+      [
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S0-0-5",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S0-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S0-1-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        "S0-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S0-2-8",
+        1
+      ],
+      [
+        1,
+        1,
+        "S0-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S0-3-7",
+        1,
+        1
+      ],
+      [
+        1,
+        "S0-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S0-4-6",
+        1,
+        1,
+        0
+      ],
+      [
+        "S0-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S0-5-5",
+        1,
+        1,
+        0,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S0-6-4",
+        1,
+        1,
+        0,
+        1,
+        "S0-6-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        "S0-7-3",
+        1,
+        1,
+        0,
+        1,
+        "S0-7-8",
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 4,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 44,
+        "height": 72
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.0.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.0.item.bar.primary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "35%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.0.item.bar.secondary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.0.item.text",
+          "show": true,
+          "text": "0\nW",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.0.item.icon",
+          "show": false,
+          "source": "loading",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.1",
+    "label": "Panel Group 2",
+    "attrs": {
+      "x": 700,
+      "y": 780,
+      "angle": 15,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.1"
+      }
+    },
+    "cells": [
+      [
+        "S1-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S1-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S1-0-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S1-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S1-1-9",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S1-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S1-2-8",
+        1,
+        0
+      ],
+      [
+        1,
+        1,
+        "S1-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S1-3-7",
+        1,
+        0,
+        1
+      ],
+      [
+        1,
+        "S1-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S1-4-6",
+        1,
+        0,
+        1,
+        1
+      ],
+      [
+        "S1-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S1-5-5",
+        1,
+        0,
+        1,
+        1,
+        "S1-5-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S1-6-4",
+        1,
+        0,
+        1,
+        1,
+        "S1-6-9",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S1-7-3",
+        1,
+        0,
+        1,
+        1,
+        "S1-7-8",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S1-8-2",
+        1,
+        0,
+        1,
+        1,
+        "S1-8-7",
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 5,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 48,
+        "height": 76
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.1.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.1.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "45%"
+          },
+          "placement": "top",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#22c55e",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.1.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.1.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.1.item.icon",
+          "show": true,
+          "source": "warning",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#f59e0b"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.2",
+    "label": "Panel Group 3",
+    "attrs": {
+      "x": 1320,
+      "y": 780,
+      "angle": 30,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.2"
+      }
+    },
+    "cells": [
+      [
+        "S2-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S2-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S2-0-10",
+        0
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S2-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S2-1-9",
+        0,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S2-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S2-2-8",
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S2-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S2-3-7",
+        0,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S2-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S2-4-6",
+        0,
+        1,
+        1,
+        1,
+        "S2-4-11"
+      ],
+      [
+        "S2-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S2-5-5",
+        0,
+        1,
+        1,
+        1,
+        "S2-5-10",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S2-6-4",
+        0,
+        1,
+        1,
+        1,
+        "S2-6-9",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S2-7-3",
+        0,
+        1,
+        1,
+        1,
+        "S2-7-8",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S2-8-2",
+        0,
+        1,
+        1,
+        1,
+        "S2-8-7",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S2-9-1",
+        0,
+        1,
+        1,
+        1,
+        "S2-9-6",
+        1,
+        1,
+        1,
+        1,
+        "S2-9-11"
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 6,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 52,
+        "height": 80
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.2.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.2.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "55%"
+          },
+          "placement": "left",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.2.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.2.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.2.item.icon",
+          "show": true,
+          "source": "wifi",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.3",
+    "label": "Panel Group 4",
+    "attrs": {
+      "x": 1940,
+      "y": 780,
+      "angle": 45,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.3"
+      }
+    },
+    "cells": [
+      [
+        "S3-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S3-0-5",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S3-1-4",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S3-2-3",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S3-3-2",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S3-3-12"
+      ],
+      [
+        1,
+        "S3-4-1",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S3-4-11",
+        1
+      ],
+      [
+        "S3-5-0",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S3-5-10",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S3-6-9",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S3-7-8",
+        1,
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 4,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 44,
+        "height": 84
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.3.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.3.item.bar.primary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "65%"
+          },
+          "placement": "right",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.3.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.3.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.3.item.icon",
+          "show": true,
+          "source": "inverter",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.4",
+    "label": "Panel Group 5",
+    "attrs": {
+      "x": 80,
+      "y": 1660,
+      "angle": 60,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.4"
+      }
+    },
+    "cells": [
+      [
+        "S4-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S4-0-5",
+        1,
+        1,
+        1,
+        0
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S4-1-4",
+        1,
+        1,
+        1,
+        0,
+        "S4-1-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        "S4-2-3",
+        1,
+        1,
+        1,
+        0,
+        "S4-2-8",
+        1
+      ],
+      [
+        1,
+        1,
+        "S4-3-2",
+        1,
+        1,
+        1,
+        0,
+        "S4-3-7",
+        1,
+        1
+      ],
+      [
+        1,
+        "S4-4-1",
+        1,
+        1,
+        1,
+        0,
+        "S4-4-6",
+        1,
+        1,
+        1
+      ],
+      [
+        "S4-5-0",
+        1,
+        1,
+        1,
+        0,
+        "S4-5-5",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        0,
+        "S4-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S4-6-9"
+      ],
+      [
+        1,
+        1,
+        0,
+        "S4-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S4-7-8",
+        1
+      ],
+      [
+        1,
+        0,
+        "S4-8-2",
+        1,
+        1,
+        1,
+        1,
+        "S4-8-7",
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 5,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 48,
+        "height": 72
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.4.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.4.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "75%"
+          },
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.4.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.4.item.text",
+          "show": true,
+          "text": "4\nW",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.4.item.icon",
+          "show": false,
+          "source": "loading",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.5",
+    "label": "Panel Group 6",
+    "attrs": {
+      "x": 700,
+      "y": 1660,
+      "angle": 75,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.5"
+      }
+    },
+    "cells": [
+      [
+        "S5-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S5-0-5",
+        1,
+        1,
+        0,
+        1,
+        "S5-0-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S5-1-4",
+        1,
+        1,
+        0,
+        1,
+        "S5-1-9",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S5-2-3",
+        1,
+        1,
+        0,
+        1,
+        "S5-2-8",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S5-3-2",
+        1,
+        1,
+        0,
+        1,
+        "S5-3-7",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S5-4-1",
+        1,
+        1,
+        0,
+        1,
+        "S5-4-6",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        "S5-5-0",
+        1,
+        1,
+        0,
+        1,
+        "S5-5-5",
+        1,
+        1,
+        1,
+        1,
+        "S5-5-10"
+      ],
+      [
+        1,
+        1,
+        0,
+        1,
+        "S5-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S5-6-9",
+        1
+      ],
+      [
+        1,
+        0,
+        1,
+        "S5-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S5-7-8",
+        1,
+        1
+      ],
+      [
+        0,
+        1,
+        "S5-8-2",
+        1,
+        1,
+        1,
+        1,
+        "S5-8-7",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S5-9-1",
+        1,
+        1,
+        1,
+        1,
+        "S5-9-6",
+        1,
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 6,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 52,
+        "height": 76
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.5.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.5.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "85%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.5.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.5.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.5.item.icon",
+          "show": true,
+          "source": "warning",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#f59e0b"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.6",
+    "label": "Panel Group 7",
+    "attrs": {
+      "x": 1320,
+      "y": 1660,
+      "angle": 0,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.6"
+      }
+    },
+    "cells": [
+      [
+        "S6-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S6-0-5",
+        1,
+        0,
+        1,
+        1,
+        "S6-0-10",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S6-1-4",
+        1,
+        0,
+        1,
+        1,
+        "S6-1-9",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S6-2-3",
+        1,
+        0,
+        1,
+        1,
+        "S6-2-8",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S6-3-2",
+        1,
+        0,
+        1,
+        1,
+        "S6-3-7",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S6-4-1",
+        1,
+        0,
+        1,
+        1,
+        "S6-4-6",
+        1,
+        1,
+        1,
+        1,
+        "S6-4-11"
+      ],
+      [
+        "S6-5-0",
+        1,
+        0,
+        1,
+        1,
+        "S6-5-5",
+        1,
+        1,
+        1,
+        1,
+        "S6-5-10",
+        1
+      ],
+      [
+        1,
+        0,
+        1,
+        1,
+        "S6-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S6-6-9",
+        1,
+        1
+      ],
+      [
+        0,
+        1,
+        1,
+        "S6-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S6-7-8",
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 4,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 44,
+        "height": 80
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.6.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.6.item.bar.primary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "35%"
+          },
+          "placement": "top",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#22c55e",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.6.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.6.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.6.item.icon",
+          "show": true,
+          "source": "wifi",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.7",
+    "label": "Panel Group 8",
+    "attrs": {
+      "x": 1940,
+      "y": 1660,
+      "angle": 15,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.7"
+      }
+    },
+    "cells": [
+      [
+        "S7-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S7-0-5",
+        0,
+        1,
+        1,
+        1,
+        "S7-0-10",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S7-1-4",
+        0,
+        1,
+        1,
+        1,
+        "S7-1-9",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S7-2-3",
+        0,
+        1,
+        1,
+        1,
+        "S7-2-8",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S7-3-2",
+        0,
+        1,
+        1,
+        1,
+        "S7-3-7",
+        1,
+        1,
+        1,
+        1,
+        "S7-3-12"
+      ],
+      [
+        1,
+        "S7-4-1",
+        0,
+        1,
+        1,
+        1,
+        "S7-4-6",
+        1,
+        1,
+        1,
+        1,
+        "S7-4-11",
+        1
+      ],
+      [
+        "S7-5-0",
+        0,
+        1,
+        1,
+        1,
+        "S7-5-5",
+        1,
+        1,
+        1,
+        1,
+        "S7-5-10",
+        1,
+        1
+      ],
+      [
+        0,
+        1,
+        1,
+        1,
+        "S7-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S7-6-9",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S7-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S7-7-8",
+        1,
+        1,
+        1,
+        0
+      ],
+      [
+        1,
+        1,
+        "S7-8-2",
+        1,
+        1,
+        1,
+        1,
+        "S7-8-7",
+        1,
+        1,
+        1,
+        0,
+        "S7-8-12"
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 5,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 48,
+        "height": 84
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.7.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.7.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "45%"
+          },
+          "placement": "left",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.7.item.bar.secondary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.7.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.7.item.icon",
+          "show": true,
+          "source": "inverter",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.8",
+    "label": "Panel Group 9",
+    "attrs": {
+      "x": 80,
+      "y": 2540,
+      "angle": 30,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.8"
+      }
+    },
+    "cells": [
+      [
+        "S8-0-0",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S8-1-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S8-2-8",
+        1
+      ],
+      [
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S8-3-7",
+        1,
+        1
+      ],
+      [
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S8-4-6",
+        1,
+        1,
+        1
+      ],
+      [
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S8-5-5",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S8-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S8-6-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        "S8-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S8-7-8",
+        1
+      ],
+      [
+        1,
+        1,
+        "S8-8-2",
+        1,
+        1,
+        1,
+        1,
+        "S8-8-7",
+        1,
+        1
+      ],
+      [
+        1,
+        "S8-9-1",
+        1,
+        1,
+        1,
+        1,
+        "S8-9-6",
+        1,
+        1,
+        0
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 6,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 52,
+        "height": 72
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.8.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.8.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "55%"
+          },
+          "placement": "right",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.8.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.8.item.text",
+          "show": true,
+          "text": "8\nW",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.8.item.icon",
+          "show": false,
+          "source": "loading",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.9",
+    "label": "Panel Group 10",
+    "attrs": {
+      "x": 700,
+      "y": 2540,
+      "angle": 45,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.9"
+      }
+    },
+    "cells": [
+      [
+        "S9-0-0",
+        1,
+        1,
+        1,
+        0,
+        "S9-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S9-0-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        0,
+        "S9-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S9-1-9",
+        1
+      ],
+      [
+        1,
+        1,
+        0,
+        "S9-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S9-2-8",
+        1,
+        1
+      ],
+      [
+        1,
+        0,
+        "S9-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S9-3-7",
+        1,
+        1,
+        1
+      ],
+      [
+        0,
+        "S9-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S9-4-6",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        "S9-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S9-5-5",
+        1,
+        1,
+        1,
+        1,
+        "S9-5-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S9-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S9-6-9",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S9-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S9-7-8",
+        1,
+        0
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 4,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 44,
+        "height": 76
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.9.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.9.item.bar.primary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "65%"
+          },
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.9.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.9.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.9.item.icon",
+          "show": true,
+          "source": "warning",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#f59e0b"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.10",
+    "label": "Panel Group 11",
+    "attrs": {
+      "x": 1320,
+      "y": 2540,
+      "angle": 60,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.10"
+      }
+    },
+    "cells": [
+      [
+        "S10-0-0",
+        1,
+        1,
+        0,
+        1,
+        "S10-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S10-0-10",
+        1
+      ],
+      [
+        1,
+        1,
+        0,
+        1,
+        "S10-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S10-1-9",
+        1,
+        1
+      ],
+      [
+        1,
+        0,
+        1,
+        "S10-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S10-2-8",
+        1,
+        1,
+        1
+      ],
+      [
+        0,
+        1,
+        "S10-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S10-3-7",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S10-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S10-4-6",
+        1,
+        1,
+        1,
+        1,
+        "S10-4-11"
+      ],
+      [
+        "S10-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S10-5-5",
+        1,
+        1,
+        1,
+        1,
+        "S10-5-10",
+        0
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S10-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S10-6-9",
+        0,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S10-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S10-7-8",
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S10-8-2",
+        1,
+        1,
+        1,
+        1,
+        "S10-8-7",
+        0,
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 5,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 48,
+        "height": 80
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.10.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.10.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "75%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.10.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.10.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.10.item.icon",
+          "show": true,
+          "source": "wifi",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.11",
+    "label": "Panel Group 12",
+    "attrs": {
+      "x": 1940,
+      "y": 2540,
+      "angle": 75,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.11"
+      }
+    },
+    "cells": [
+      [
+        "S11-0-0",
+        1,
+        0,
+        1,
+        1,
+        "S11-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S11-0-10",
+        1,
+        1
+      ],
+      [
+        1,
+        0,
+        1,
+        1,
+        "S11-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S11-1-9",
+        1,
+        1,
+        1
+      ],
+      [
+        0,
+        1,
+        1,
+        "S11-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S11-2-8",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S11-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S11-3-7",
+        1,
+        1,
+        1,
+        1,
+        0
+      ],
+      [
+        1,
+        "S11-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S11-4-6",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ],
+      [
+        "S11-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S11-5-5",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S11-6-4",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S11-7-3",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S11-8-2",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S11-8-12"
+      ],
+      [
+        1,
+        "S11-9-1",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S11-9-11",
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 6,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 52,
+        "height": 84
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.11.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.11.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "85%"
+          },
+          "placement": "top",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#22c55e",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.11.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.11.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.11.item.icon",
+          "show": true,
+          "source": "inverter",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.12",
+    "label": "Panel Group 13",
+    "attrs": {
+      "x": 80,
+      "y": 3420,
+      "angle": 0,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.12"
+      }
+    },
+    "cells": [
+      [
+        "S12-0-0",
+        0,
+        1,
+        1,
+        1,
+        "S12-0-5",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        0,
+        1,
+        1,
+        1,
+        "S12-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S12-1-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        "S12-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S12-2-8",
+        1
+      ],
+      [
+        1,
+        1,
+        "S12-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S12-3-7",
+        1,
+        1
+      ],
+      [
+        1,
+        "S12-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S12-4-6",
+        1,
+        1,
+        1
+      ],
+      [
+        "S12-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S12-5-5",
+        1,
+        1,
+        1,
+        0
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S12-6-4",
+        1,
+        1,
+        1,
+        0,
+        "S12-6-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        "S12-7-3",
+        1,
+        1,
+        1,
+        0,
+        "S12-7-8",
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 4,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 44,
+        "height": 72
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.12.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.12.item.bar.primary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "35%"
+          },
+          "placement": "left",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.12.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.12.item.text",
+          "show": true,
+          "text": "12\nW",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.12.item.icon",
+          "show": false,
+          "source": "loading",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.13",
+    "label": "Panel Group 14",
+    "attrs": {
+      "x": 700,
+      "y": 3420,
+      "angle": 15,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.13"
+      }
+    },
+    "cells": [
+      [
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S13-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S13-0-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S13-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S13-1-9",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S13-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S13-2-8",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S13-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S13-3-7",
+        1,
+        1,
+        0
+      ],
+      [
+        1,
+        "S13-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S13-4-6",
+        1,
+        1,
+        0,
+        1
+      ],
+      [
+        "S13-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S13-5-5",
+        1,
+        1,
+        0,
+        1,
+        "S13-5-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S13-6-4",
+        1,
+        1,
+        0,
+        1,
+        "S13-6-9",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S13-7-3",
+        1,
+        1,
+        0,
+        1,
+        "S13-7-8",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S13-8-2",
+        1,
+        1,
+        0,
+        1,
+        "S13-8-7",
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 5,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 48,
+        "height": 76
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.13.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.13.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "45%"
+          },
+          "placement": "right",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.13.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.13.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.13.item.icon",
+          "show": true,
+          "source": "warning",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#f59e0b"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.14",
+    "label": "Panel Group 15",
+    "attrs": {
+      "x": 1320,
+      "y": 3420,
+      "angle": 30,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.0"
+      }
+    },
+    "cells": [
+      [
+        "S14-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S14-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S14-0-10",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S14-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S14-1-9",
+        1,
+        0
+      ],
+      [
+        1,
+        1,
+        1,
+        "S14-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S14-2-8",
+        1,
+        0,
+        1
+      ],
+      [
+        1,
+        1,
+        "S14-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S14-3-7",
+        1,
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        "S14-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S14-4-6",
+        1,
+        0,
+        1,
+        1,
+        "S14-4-11"
+      ],
+      [
+        "S14-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S14-5-5",
+        1,
+        0,
+        1,
+        1,
+        "S14-5-10",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S14-6-4",
+        1,
+        0,
+        1,
+        1,
+        "S14-6-9",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S14-7-3",
+        1,
+        0,
+        1,
+        1,
+        "S14-7-8",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S14-8-2",
+        1,
+        0,
+        1,
+        1,
+        "S14-8-7",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S14-9-1",
+        1,
+        0,
+        1,
+        1,
+        "S14-9-6",
+        1,
+        1,
+        1,
+        1,
+        "S14-9-11"
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 6,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 52,
+        "height": 80
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.14.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.14.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "55%"
+          },
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.14.item.bar.secondary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.14.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.14.item.icon",
+          "show": true,
+          "source": "wifi",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.15",
+    "label": "Panel Group 16",
+    "attrs": {
+      "x": 1940,
+      "y": 3420,
+      "angle": 45,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.1"
+      }
+    },
+    "cells": [
+      [
+        "S15-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S15-0-5",
+        1,
+        1,
+        1,
+        1,
+        "S15-0-10",
+        0,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S15-1-4",
+        1,
+        1,
+        1,
+        1,
+        "S15-1-9",
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S15-2-3",
+        1,
+        1,
+        1,
+        1,
+        "S15-2-8",
+        0,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S15-3-2",
+        1,
+        1,
+        1,
+        1,
+        "S15-3-7",
+        0,
+        1,
+        1,
+        1,
+        "S15-3-12"
+      ],
+      [
+        1,
+        "S15-4-1",
+        1,
+        1,
+        1,
+        1,
+        "S15-4-6",
+        0,
+        1,
+        1,
+        1,
+        "S15-4-11",
+        1
+      ],
+      [
+        "S15-5-0",
+        1,
+        1,
+        1,
+        1,
+        "S15-5-5",
+        0,
+        1,
+        1,
+        1,
+        "S15-5-10",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S15-6-4",
+        0,
+        1,
+        1,
+        1,
+        "S15-6-9",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S15-7-3",
+        0,
+        1,
+        1,
+        1,
+        "S15-7-8",
+        1,
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 4,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 44,
+        "height": 84
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.15.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.15.item.bar.primary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "65%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.15.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.15.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.15.item.icon",
+          "show": true,
+          "source": "inverter",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.16",
+    "label": "Panel Group 17",
+    "attrs": {
+      "x": 80,
+      "y": 4300,
+      "angle": 60,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.2"
+      }
+    },
+    "cells": [
+      [
+        "S16-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S16-0-5",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S16-1-4",
+        1,
+        1,
+        1,
+        1,
+        0
+      ],
+      [
+        1,
+        1,
+        1,
+        "S16-2-3",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1
+      ],
+      [
+        1,
+        1,
+        "S16-3-2",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1
+      ],
+      [
+        1,
+        "S16-4-1",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1
+      ],
+      [
+        "S16-5-0",
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S16-6-9"
+      ],
+      [
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S16-7-8",
+        1
+      ],
+      [
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        "S16-8-7",
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "destroy",
+    "gap": {
+      "x": 5,
+      "y": 4
+    },
+    "item": {
+      "size": {
+        "width": 48,
+        "height": 72
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "upright",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.16.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.16.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "75%"
+          },
+          "placement": "top",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#22c55e",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.16.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.16.item.text",
+          "show": true,
+          "text": "16\nW",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.16.item.icon",
+          "show": false,
+          "source": "loading",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "black"
+        }
+      ]
+    }
+  },
+  {
+    "type": "grid",
+    "id": "panelGroup.17",
+    "label": "Panel Group 18",
+    "attrs": {
+      "x": 700,
+      "y": 4300,
+      "angle": 75,
+      "display": "panelGroup",
+      "metadata": {
+        "parent": "inverter.3"
+      }
+    },
+    "cells": [
+      [
+        "S17-0-0",
+        1,
+        1,
+        1,
+        1,
+        "S17-0-5",
+        1,
+        1,
+        1,
+        0,
+        "S17-0-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        "S17-1-4",
+        1,
+        1,
+        1,
+        0,
+        "S17-1-9",
+        1
+      ],
+      [
+        1,
+        1,
+        1,
+        "S17-2-3",
+        1,
+        1,
+        1,
+        0,
+        "S17-2-8",
+        1,
+        1
+      ],
+      [
+        1,
+        1,
+        "S17-3-2",
+        1,
+        1,
+        1,
+        0,
+        "S17-3-7",
+        1,
+        1,
+        1
+      ],
+      [
+        1,
+        "S17-4-1",
+        1,
+        1,
+        1,
+        0,
+        "S17-4-6",
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        "S17-5-0",
+        1,
+        1,
+        1,
+        0,
+        "S17-5-5",
+        1,
+        1,
+        1,
+        1,
+        "S17-5-10"
+      ],
+      [
+        1,
+        1,
+        1,
+        0,
+        "S17-6-4",
+        1,
+        1,
+        1,
+        1,
+        "S17-6-9",
+        1
+      ],
+      [
+        1,
+        1,
+        0,
+        "S17-7-3",
+        1,
+        1,
+        1,
+        1,
+        "S17-7-8",
+        1,
+        1
+      ],
+      [
+        1,
+        0,
+        "S17-8-2",
+        1,
+        1,
+        1,
+        1,
+        "S17-8-7",
+        1,
+        1,
+        1
+      ],
+      [
+        0,
+        "S17-9-1",
+        1,
+        1,
+        1,
+        1,
+        "S17-9-6",
+        1,
+        1,
+        1,
+        1
+      ]
+    ],
+    "inactiveCellStrategy": "hide",
+    "gap": {
+      "x": 6,
+      "y": 5
+    },
+    "item": {
+      "size": {
+        "width": 52,
+        "height": 76
+      },
+      "padding": {
+        "top": 3,
+        "right": 3,
+        "bottom": 3,
+        "left": 3
+      },
+      "contentOrientation": "follow-item",
+      "components": [
+        {
+          "type": "background",
+          "id": "panelGroup.17.item.bg",
+          "source": {
+            "type": "rect",
+            "fill": "#f8fafc",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 6
+          },
+          "size": {
+            "width": {
+              "value": 100,
+              "unit": "%"
+            },
+            "height": {
+              "value": 100,
+              "unit": "%"
+            }
+          },
+          "tint": 16777215
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.17.item.bar.primary",
+          "show": true,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "85%"
+          },
+          "placement": "left",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "bar",
+          "id": "panelGroup.17.item.bar.secondary",
+          "show": false,
+          "source": {
+            "type": "rect",
+            "fill": "white",
+            "borderColor": "primary.dark",
+            "borderWidth": 2,
+            "radius": 3
+          },
+          "size": {
+            "width": "100%",
+            "height": "100%"
+          },
+          "placement": "bottom",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "primary.default",
+          "animation": false,
+          "animationDuration": 200
+        },
+        {
+          "type": "text",
+          "id": "panelGroup.17.item.text",
+          "show": false,
+          "text": "",
+          "placement": "center",
+          "margin": {
+            "top": 4,
+            "right": 4,
+            "bottom": 4,
+            "left": 4
+          },
+          "tint": "white",
+          "split": 0,
+          "style": {
+            "fontWeight": "600",
+            "fontSize": "auto",
+            "autoFont": {
+              "min": 8,
+              "max": 14
+            },
+            "align": "center",
+            "fill": "white",
+            "breakWords": true,
+            "wordWrapWidth": "auto",
+            "overflow": "ellipsis"
+          }
+        },
+        {
+          "type": "icon",
+          "id": "panelGroup.17.item.icon",
+          "show": true,
+          "source": "warning",
+          "size": 20,
+          "placement": "center",
+          "margin": {
+            "top": 0,
+            "right": 0,
+            "bottom": 0,
+            "left": 0
+          },
+          "tint": "#f59e0b"
+        }
+      ]
+    }
+  },
+  {
+    "type": "group",
+    "id": "fixture.strings",
+    "label": "strings",
+    "attrs": {
+      "x": 0,
+      "y": 0
+    },
+    "children": [
+      {
+        "type": "relations",
+        "id": "string.0",
+        "label": "String 1",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.0"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.0.0.0",
+            "target": "panelGroup.0.0.1"
+          },
+          {
+            "source": "panelGroup.0.0.1",
+            "target": "panelGroup.0.0.2"
+          },
+          {
+            "source": "panelGroup.0.0.2",
+            "target": "panelGroup.0.0.3"
+          },
+          {
+            "source": "panelGroup.0.0.3",
+            "target": "panelGroup.0.0.4"
+          },
+          {
+            "source": "panelGroup.0.0.4",
+            "target": "panelGroup.0.0.5"
+          },
+          {
+            "source": "panelGroup.0.0.5",
+            "target": "panelGroup.0.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.1",
+        "label": "String 2",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.1"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.0.1.0",
+            "target": "panelGroup.0.1.1"
+          },
+          {
+            "source": "panelGroup.0.1.1",
+            "target": "panelGroup.0.1.2"
+          },
+          {
+            "source": "panelGroup.0.1.2",
+            "target": "panelGroup.0.1.3"
+          },
+          {
+            "source": "panelGroup.0.1.3",
+            "target": "panelGroup.0.1.4"
+          },
+          {
+            "source": "panelGroup.0.1.4",
+            "target": "panelGroup.0.1.5"
+          },
+          {
+            "source": "panelGroup.0.1.5",
+            "target": "panelGroup.0.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.2",
+        "label": "String 3",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.2"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.0.2.0",
+            "target": "panelGroup.0.2.1"
+          },
+          {
+            "source": "panelGroup.0.2.1",
+            "target": "panelGroup.0.2.2"
+          },
+          {
+            "source": "panelGroup.0.2.2",
+            "target": "panelGroup.0.2.3"
+          },
+          {
+            "source": "panelGroup.0.2.3",
+            "target": "panelGroup.0.2.4"
+          },
+          {
+            "source": "panelGroup.0.2.4",
+            "target": "panelGroup.0.2.5"
+          },
+          {
+            "source": "panelGroup.0.2.5",
+            "target": "panelGroup.0.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.3",
+        "label": "String 4",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.3"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.1.0.0",
+            "target": "panelGroup.1.0.1"
+          },
+          {
+            "source": "panelGroup.1.0.1",
+            "target": "panelGroup.1.0.2"
+          },
+          {
+            "source": "panelGroup.1.0.2",
+            "target": "panelGroup.1.0.3"
+          },
+          {
+            "source": "panelGroup.1.0.3",
+            "target": "panelGroup.1.0.4"
+          },
+          {
+            "source": "panelGroup.1.0.4",
+            "target": "panelGroup.1.0.5"
+          },
+          {
+            "source": "panelGroup.1.0.5",
+            "target": "panelGroup.1.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.4",
+        "label": "String 5",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.4"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.1.1.0",
+            "target": "panelGroup.1.1.1"
+          },
+          {
+            "source": "panelGroup.1.1.1",
+            "target": "panelGroup.1.1.2"
+          },
+          {
+            "source": "panelGroup.1.1.2",
+            "target": "panelGroup.1.1.3"
+          },
+          {
+            "source": "panelGroup.1.1.3",
+            "target": "panelGroup.1.1.4"
+          },
+          {
+            "source": "panelGroup.1.1.4",
+            "target": "panelGroup.1.1.5"
+          },
+          {
+            "source": "panelGroup.1.1.5",
+            "target": "panelGroup.1.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.5",
+        "label": "String 6",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.5"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.1.2.0",
+            "target": "panelGroup.1.2.1"
+          },
+          {
+            "source": "panelGroup.1.2.1",
+            "target": "panelGroup.1.2.2"
+          },
+          {
+            "source": "panelGroup.1.2.2",
+            "target": "panelGroup.1.2.3"
+          },
+          {
+            "source": "panelGroup.1.2.3",
+            "target": "panelGroup.1.2.4"
+          },
+          {
+            "source": "panelGroup.1.2.4",
+            "target": "panelGroup.1.2.5"
+          },
+          {
+            "source": "panelGroup.1.2.5",
+            "target": "panelGroup.1.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.6",
+        "label": "String 7",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.6"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.2.0.0",
+            "target": "panelGroup.2.0.1"
+          },
+          {
+            "source": "panelGroup.2.0.1",
+            "target": "panelGroup.2.0.2"
+          },
+          {
+            "source": "panelGroup.2.0.2",
+            "target": "panelGroup.2.0.3"
+          },
+          {
+            "source": "panelGroup.2.0.3",
+            "target": "panelGroup.2.0.4"
+          },
+          {
+            "source": "panelGroup.2.0.4",
+            "target": "panelGroup.2.0.5"
+          },
+          {
+            "source": "panelGroup.2.0.5",
+            "target": "panelGroup.2.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.7",
+        "label": "String 8",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.7"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.2.1.0",
+            "target": "panelGroup.2.1.1"
+          },
+          {
+            "source": "panelGroup.2.1.1",
+            "target": "panelGroup.2.1.2"
+          },
+          {
+            "source": "panelGroup.2.1.2",
+            "target": "panelGroup.2.1.3"
+          },
+          {
+            "source": "panelGroup.2.1.3",
+            "target": "panelGroup.2.1.4"
+          },
+          {
+            "source": "panelGroup.2.1.4",
+            "target": "panelGroup.2.1.5"
+          },
+          {
+            "source": "panelGroup.2.1.5",
+            "target": "panelGroup.2.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.8",
+        "label": "String 9",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.8"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.2.2.0",
+            "target": "panelGroup.2.2.1"
+          },
+          {
+            "source": "panelGroup.2.2.1",
+            "target": "panelGroup.2.2.2"
+          },
+          {
+            "source": "panelGroup.2.2.2",
+            "target": "panelGroup.2.2.3"
+          },
+          {
+            "source": "panelGroup.2.2.3",
+            "target": "panelGroup.2.2.4"
+          },
+          {
+            "source": "panelGroup.2.2.4",
+            "target": "panelGroup.2.2.5"
+          },
+          {
+            "source": "panelGroup.2.2.5",
+            "target": "panelGroup.2.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.9",
+        "label": "String 10",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.9"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.3.0.0",
+            "target": "panelGroup.3.0.1"
+          },
+          {
+            "source": "panelGroup.3.0.1",
+            "target": "panelGroup.3.0.2"
+          },
+          {
+            "source": "panelGroup.3.0.2",
+            "target": "panelGroup.3.0.3"
+          },
+          {
+            "source": "panelGroup.3.0.3",
+            "target": "panelGroup.3.0.4"
+          },
+          {
+            "source": "panelGroup.3.0.4",
+            "target": "panelGroup.3.0.5"
+          },
+          {
+            "source": "panelGroup.3.0.5",
+            "target": "panelGroup.3.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.10",
+        "label": "String 11",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.10"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.3.1.0",
+            "target": "panelGroup.3.1.1"
+          },
+          {
+            "source": "panelGroup.3.1.1",
+            "target": "panelGroup.3.1.2"
+          },
+          {
+            "source": "panelGroup.3.1.2",
+            "target": "panelGroup.3.1.3"
+          },
+          {
+            "source": "panelGroup.3.1.3",
+            "target": "panelGroup.3.1.4"
+          },
+          {
+            "source": "panelGroup.3.1.4",
+            "target": "panelGroup.3.1.5"
+          },
+          {
+            "source": "panelGroup.3.1.5",
+            "target": "panelGroup.3.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.11",
+        "label": "String 12",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.11"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.3.2.0",
+            "target": "panelGroup.3.2.1"
+          },
+          {
+            "source": "panelGroup.3.2.1",
+            "target": "panelGroup.3.2.2"
+          },
+          {
+            "source": "panelGroup.3.2.2",
+            "target": "panelGroup.3.2.3"
+          },
+          {
+            "source": "panelGroup.3.2.3",
+            "target": "panelGroup.3.2.4"
+          },
+          {
+            "source": "panelGroup.3.2.4",
+            "target": "panelGroup.3.2.5"
+          },
+          {
+            "source": "panelGroup.3.2.5",
+            "target": "panelGroup.3.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.12",
+        "label": "String 13",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.12"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.4.0.0",
+            "target": "panelGroup.4.0.1"
+          },
+          {
+            "source": "panelGroup.4.0.1",
+            "target": "panelGroup.4.0.2"
+          },
+          {
+            "source": "panelGroup.4.0.2",
+            "target": "panelGroup.4.0.3"
+          },
+          {
+            "source": "panelGroup.4.0.3",
+            "target": "panelGroup.4.0.4"
+          },
+          {
+            "source": "panelGroup.4.0.4",
+            "target": "panelGroup.4.0.5"
+          },
+          {
+            "source": "panelGroup.4.0.5",
+            "target": "panelGroup.4.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.13",
+        "label": "String 14",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.13"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.4.1.0",
+            "target": "panelGroup.4.1.1"
+          },
+          {
+            "source": "panelGroup.4.1.1",
+            "target": "panelGroup.4.1.2"
+          },
+          {
+            "source": "panelGroup.4.1.2",
+            "target": "panelGroup.4.1.3"
+          },
+          {
+            "source": "panelGroup.4.1.3",
+            "target": "panelGroup.4.1.4"
+          },
+          {
+            "source": "panelGroup.4.1.4",
+            "target": "panelGroup.4.1.5"
+          },
+          {
+            "source": "panelGroup.4.1.5",
+            "target": "panelGroup.4.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.14",
+        "label": "String 15",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.0"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.4.2.0",
+            "target": "panelGroup.4.2.1"
+          },
+          {
+            "source": "panelGroup.4.2.1",
+            "target": "panelGroup.4.2.2"
+          },
+          {
+            "source": "panelGroup.4.2.2",
+            "target": "panelGroup.4.2.3"
+          },
+          {
+            "source": "panelGroup.4.2.3",
+            "target": "panelGroup.4.2.4"
+          },
+          {
+            "source": "panelGroup.4.2.4",
+            "target": "panelGroup.4.2.5"
+          },
+          {
+            "source": "panelGroup.4.2.5",
+            "target": "panelGroup.4.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.15",
+        "label": "String 16",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.1"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.5.0.0",
+            "target": "panelGroup.5.0.1"
+          },
+          {
+            "source": "panelGroup.5.0.1",
+            "target": "panelGroup.5.0.2"
+          },
+          {
+            "source": "panelGroup.5.0.2",
+            "target": "panelGroup.5.0.3"
+          },
+          {
+            "source": "panelGroup.5.0.3",
+            "target": "panelGroup.5.0.4"
+          },
+          {
+            "source": "panelGroup.5.0.4",
+            "target": "panelGroup.5.0.5"
+          },
+          {
+            "source": "panelGroup.5.0.5",
+            "target": "panelGroup.5.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.16",
+        "label": "String 17",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.2"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.5.1.0",
+            "target": "panelGroup.5.1.1"
+          },
+          {
+            "source": "panelGroup.5.1.1",
+            "target": "panelGroup.5.1.2"
+          },
+          {
+            "source": "panelGroup.5.1.2",
+            "target": "panelGroup.5.1.3"
+          },
+          {
+            "source": "panelGroup.5.1.3",
+            "target": "panelGroup.5.1.4"
+          },
+          {
+            "source": "panelGroup.5.1.4",
+            "target": "panelGroup.5.1.5"
+          },
+          {
+            "source": "panelGroup.5.1.5",
+            "target": "panelGroup.5.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.17",
+        "label": "String 18",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.3"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.5.2.0",
+            "target": "panelGroup.5.2.1"
+          },
+          {
+            "source": "panelGroup.5.2.1",
+            "target": "panelGroup.5.2.2"
+          },
+          {
+            "source": "panelGroup.5.2.2",
+            "target": "panelGroup.5.2.3"
+          },
+          {
+            "source": "panelGroup.5.2.3",
+            "target": "panelGroup.5.2.4"
+          },
+          {
+            "source": "panelGroup.5.2.4",
+            "target": "panelGroup.5.2.5"
+          },
+          {
+            "source": "panelGroup.5.2.5",
+            "target": "panelGroup.5.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.18",
+        "label": "String 19",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.4"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.6.0.0",
+            "target": "panelGroup.6.0.1"
+          },
+          {
+            "source": "panelGroup.6.0.1",
+            "target": "panelGroup.6.0.2"
+          },
+          {
+            "source": "panelGroup.6.0.2",
+            "target": "panelGroup.6.0.3"
+          },
+          {
+            "source": "panelGroup.6.0.3",
+            "target": "panelGroup.6.0.4"
+          },
+          {
+            "source": "panelGroup.6.0.4",
+            "target": "panelGroup.6.0.5"
+          },
+          {
+            "source": "panelGroup.6.0.5",
+            "target": "panelGroup.6.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.19",
+        "label": "String 20",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.5"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.6.1.0",
+            "target": "panelGroup.6.1.1"
+          },
+          {
+            "source": "panelGroup.6.1.1",
+            "target": "panelGroup.6.1.2"
+          },
+          {
+            "source": "panelGroup.6.1.2",
+            "target": "panelGroup.6.1.3"
+          },
+          {
+            "source": "panelGroup.6.1.3",
+            "target": "panelGroup.6.1.4"
+          },
+          {
+            "source": "panelGroup.6.1.4",
+            "target": "panelGroup.6.1.5"
+          },
+          {
+            "source": "panelGroup.6.1.5",
+            "target": "panelGroup.6.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.20",
+        "label": "String 21",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.6"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.6.2.0",
+            "target": "panelGroup.6.2.1"
+          },
+          {
+            "source": "panelGroup.6.2.1",
+            "target": "panelGroup.6.2.2"
+          },
+          {
+            "source": "panelGroup.6.2.2",
+            "target": "panelGroup.6.2.3"
+          },
+          {
+            "source": "panelGroup.6.2.3",
+            "target": "panelGroup.6.2.4"
+          },
+          {
+            "source": "panelGroup.6.2.4",
+            "target": "panelGroup.6.2.5"
+          },
+          {
+            "source": "panelGroup.6.2.5",
+            "target": "panelGroup.6.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.21",
+        "label": "String 22",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.7"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.7.0.0",
+            "target": "panelGroup.7.0.1"
+          },
+          {
+            "source": "panelGroup.7.0.1",
+            "target": "panelGroup.7.0.2"
+          },
+          {
+            "source": "panelGroup.7.0.2",
+            "target": "panelGroup.7.0.3"
+          },
+          {
+            "source": "panelGroup.7.0.3",
+            "target": "panelGroup.7.0.4"
+          },
+          {
+            "source": "panelGroup.7.0.4",
+            "target": "panelGroup.7.0.5"
+          },
+          {
+            "source": "panelGroup.7.0.5",
+            "target": "panelGroup.7.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.22",
+        "label": "String 23",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.8"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.7.1.0",
+            "target": "panelGroup.7.1.1"
+          },
+          {
+            "source": "panelGroup.7.1.1",
+            "target": "panelGroup.7.1.2"
+          },
+          {
+            "source": "panelGroup.7.1.2",
+            "target": "panelGroup.7.1.3"
+          },
+          {
+            "source": "panelGroup.7.1.3",
+            "target": "panelGroup.7.1.4"
+          },
+          {
+            "source": "panelGroup.7.1.4",
+            "target": "panelGroup.7.1.5"
+          },
+          {
+            "source": "panelGroup.7.1.5",
+            "target": "panelGroup.7.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.23",
+        "label": "String 24",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.9"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.7.2.0",
+            "target": "panelGroup.7.2.1"
+          },
+          {
+            "source": "panelGroup.7.2.1",
+            "target": "panelGroup.7.2.2"
+          },
+          {
+            "source": "panelGroup.7.2.2",
+            "target": "panelGroup.7.2.3"
+          },
+          {
+            "source": "panelGroup.7.2.3",
+            "target": "panelGroup.7.2.4"
+          },
+          {
+            "source": "panelGroup.7.2.4",
+            "target": "panelGroup.7.2.5"
+          },
+          {
+            "source": "panelGroup.7.2.5",
+            "target": "panelGroup.7.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.24",
+        "label": "String 25",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.10"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.8.0.0",
+            "target": "panelGroup.8.0.1"
+          },
+          {
+            "source": "panelGroup.8.0.1",
+            "target": "panelGroup.8.0.2"
+          },
+          {
+            "source": "panelGroup.8.0.2",
+            "target": "panelGroup.8.0.3"
+          },
+          {
+            "source": "panelGroup.8.0.3",
+            "target": "panelGroup.8.0.4"
+          },
+          {
+            "source": "panelGroup.8.0.4",
+            "target": "panelGroup.8.0.5"
+          },
+          {
+            "source": "panelGroup.8.0.5",
+            "target": "panelGroup.8.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.25",
+        "label": "String 26",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.11"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.8.1.0",
+            "target": "panelGroup.8.1.1"
+          },
+          {
+            "source": "panelGroup.8.1.1",
+            "target": "panelGroup.8.1.2"
+          },
+          {
+            "source": "panelGroup.8.1.2",
+            "target": "panelGroup.8.1.3"
+          },
+          {
+            "source": "panelGroup.8.1.3",
+            "target": "panelGroup.8.1.4"
+          },
+          {
+            "source": "panelGroup.8.1.4",
+            "target": "panelGroup.8.1.5"
+          },
+          {
+            "source": "panelGroup.8.1.5",
+            "target": "panelGroup.8.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.26",
+        "label": "String 27",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.12"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.8.2.0",
+            "target": "panelGroup.8.2.1"
+          },
+          {
+            "source": "panelGroup.8.2.1",
+            "target": "panelGroup.8.2.2"
+          },
+          {
+            "source": "panelGroup.8.2.2",
+            "target": "panelGroup.8.2.3"
+          },
+          {
+            "source": "panelGroup.8.2.3",
+            "target": "panelGroup.8.2.4"
+          },
+          {
+            "source": "panelGroup.8.2.4",
+            "target": "panelGroup.8.2.5"
+          },
+          {
+            "source": "panelGroup.8.2.5",
+            "target": "panelGroup.8.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.27",
+        "label": "String 28",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.13"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.9.0.0",
+            "target": "panelGroup.9.0.1"
+          },
+          {
+            "source": "panelGroup.9.0.1",
+            "target": "panelGroup.9.0.2"
+          },
+          {
+            "source": "panelGroup.9.0.2",
+            "target": "panelGroup.9.0.3"
+          },
+          {
+            "source": "panelGroup.9.0.3",
+            "target": "panelGroup.9.0.4"
+          },
+          {
+            "source": "panelGroup.9.0.4",
+            "target": "panelGroup.9.0.5"
+          },
+          {
+            "source": "panelGroup.9.0.5",
+            "target": "panelGroup.9.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.28",
+        "label": "String 29",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.0"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.9.1.0",
+            "target": "panelGroup.9.1.1"
+          },
+          {
+            "source": "panelGroup.9.1.1",
+            "target": "panelGroup.9.1.2"
+          },
+          {
+            "source": "panelGroup.9.1.2",
+            "target": "panelGroup.9.1.3"
+          },
+          {
+            "source": "panelGroup.9.1.3",
+            "target": "panelGroup.9.1.4"
+          },
+          {
+            "source": "panelGroup.9.1.4",
+            "target": "panelGroup.9.1.5"
+          },
+          {
+            "source": "panelGroup.9.1.5",
+            "target": "panelGroup.9.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.29",
+        "label": "String 30",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.1"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.9.2.0",
+            "target": "panelGroup.9.2.1"
+          },
+          {
+            "source": "panelGroup.9.2.1",
+            "target": "panelGroup.9.2.2"
+          },
+          {
+            "source": "panelGroup.9.2.2",
+            "target": "panelGroup.9.2.3"
+          },
+          {
+            "source": "panelGroup.9.2.3",
+            "target": "panelGroup.9.2.4"
+          },
+          {
+            "source": "panelGroup.9.2.4",
+            "target": "panelGroup.9.2.5"
+          },
+          {
+            "source": "panelGroup.9.2.5",
+            "target": "panelGroup.9.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.30",
+        "label": "String 31",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.2"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.10.0.0",
+            "target": "panelGroup.10.0.1"
+          },
+          {
+            "source": "panelGroup.10.0.1",
+            "target": "panelGroup.10.0.2"
+          },
+          {
+            "source": "panelGroup.10.0.2",
+            "target": "panelGroup.10.0.3"
+          },
+          {
+            "source": "panelGroup.10.0.3",
+            "target": "panelGroup.10.0.4"
+          },
+          {
+            "source": "panelGroup.10.0.4",
+            "target": "panelGroup.10.0.5"
+          },
+          {
+            "source": "panelGroup.10.0.5",
+            "target": "panelGroup.10.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.31",
+        "label": "String 32",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.3"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.10.1.0",
+            "target": "panelGroup.10.1.1"
+          },
+          {
+            "source": "panelGroup.10.1.1",
+            "target": "panelGroup.10.1.2"
+          },
+          {
+            "source": "panelGroup.10.1.2",
+            "target": "panelGroup.10.1.3"
+          },
+          {
+            "source": "panelGroup.10.1.3",
+            "target": "panelGroup.10.1.4"
+          },
+          {
+            "source": "panelGroup.10.1.4",
+            "target": "panelGroup.10.1.5"
+          },
+          {
+            "source": "panelGroup.10.1.5",
+            "target": "panelGroup.10.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.32",
+        "label": "String 33",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.4"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.10.2.0",
+            "target": "panelGroup.10.2.1"
+          },
+          {
+            "source": "panelGroup.10.2.1",
+            "target": "panelGroup.10.2.2"
+          },
+          {
+            "source": "panelGroup.10.2.2",
+            "target": "panelGroup.10.2.3"
+          },
+          {
+            "source": "panelGroup.10.2.3",
+            "target": "panelGroup.10.2.4"
+          },
+          {
+            "source": "panelGroup.10.2.4",
+            "target": "panelGroup.10.2.5"
+          },
+          {
+            "source": "panelGroup.10.2.5",
+            "target": "panelGroup.10.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.33",
+        "label": "String 34",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.5"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.11.0.0",
+            "target": "panelGroup.11.0.1"
+          },
+          {
+            "source": "panelGroup.11.0.1",
+            "target": "panelGroup.11.0.2"
+          },
+          {
+            "source": "panelGroup.11.0.2",
+            "target": "panelGroup.11.0.3"
+          },
+          {
+            "source": "panelGroup.11.0.3",
+            "target": "panelGroup.11.0.4"
+          },
+          {
+            "source": "panelGroup.11.0.4",
+            "target": "panelGroup.11.0.5"
+          },
+          {
+            "source": "panelGroup.11.0.5",
+            "target": "panelGroup.11.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.34",
+        "label": "String 35",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.6"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.11.1.0",
+            "target": "panelGroup.11.1.1"
+          },
+          {
+            "source": "panelGroup.11.1.1",
+            "target": "panelGroup.11.1.2"
+          },
+          {
+            "source": "panelGroup.11.1.2",
+            "target": "panelGroup.11.1.3"
+          },
+          {
+            "source": "panelGroup.11.1.3",
+            "target": "panelGroup.11.1.4"
+          },
+          {
+            "source": "panelGroup.11.1.4",
+            "target": "panelGroup.11.1.5"
+          },
+          {
+            "source": "panelGroup.11.1.5",
+            "target": "panelGroup.11.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.35",
+        "label": "String 36",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.7"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.11.2.0",
+            "target": "panelGroup.11.2.1"
+          },
+          {
+            "source": "panelGroup.11.2.1",
+            "target": "panelGroup.11.2.2"
+          },
+          {
+            "source": "panelGroup.11.2.2",
+            "target": "panelGroup.11.2.3"
+          },
+          {
+            "source": "panelGroup.11.2.3",
+            "target": "panelGroup.11.2.4"
+          },
+          {
+            "source": "panelGroup.11.2.4",
+            "target": "panelGroup.11.2.5"
+          },
+          {
+            "source": "panelGroup.11.2.5",
+            "target": "panelGroup.11.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.36",
+        "label": "String 37",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.8"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.12.0.0",
+            "target": "panelGroup.12.0.1"
+          },
+          {
+            "source": "panelGroup.12.0.1",
+            "target": "panelGroup.12.0.2"
+          },
+          {
+            "source": "panelGroup.12.0.2",
+            "target": "panelGroup.12.0.3"
+          },
+          {
+            "source": "panelGroup.12.0.3",
+            "target": "panelGroup.12.0.4"
+          },
+          {
+            "source": "panelGroup.12.0.4",
+            "target": "panelGroup.12.0.5"
+          },
+          {
+            "source": "panelGroup.12.0.5",
+            "target": "panelGroup.12.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.37",
+        "label": "String 38",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.9"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.12.1.0",
+            "target": "panelGroup.12.1.1"
+          },
+          {
+            "source": "panelGroup.12.1.1",
+            "target": "panelGroup.12.1.2"
+          },
+          {
+            "source": "panelGroup.12.1.2",
+            "target": "panelGroup.12.1.3"
+          },
+          {
+            "source": "panelGroup.12.1.3",
+            "target": "panelGroup.12.1.4"
+          },
+          {
+            "source": "panelGroup.12.1.4",
+            "target": "panelGroup.12.1.5"
+          },
+          {
+            "source": "panelGroup.12.1.5",
+            "target": "panelGroup.12.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.38",
+        "label": "String 39",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.10"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.12.2.0",
+            "target": "panelGroup.12.2.1"
+          },
+          {
+            "source": "panelGroup.12.2.1",
+            "target": "panelGroup.12.2.2"
+          },
+          {
+            "source": "panelGroup.12.2.2",
+            "target": "panelGroup.12.2.3"
+          },
+          {
+            "source": "panelGroup.12.2.3",
+            "target": "panelGroup.12.2.4"
+          },
+          {
+            "source": "panelGroup.12.2.4",
+            "target": "panelGroup.12.2.5"
+          },
+          {
+            "source": "panelGroup.12.2.5",
+            "target": "panelGroup.12.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.39",
+        "label": "String 40",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.11"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.13.0.0",
+            "target": "panelGroup.13.0.1"
+          },
+          {
+            "source": "panelGroup.13.0.1",
+            "target": "panelGroup.13.0.2"
+          },
+          {
+            "source": "panelGroup.13.0.2",
+            "target": "panelGroup.13.0.3"
+          },
+          {
+            "source": "panelGroup.13.0.3",
+            "target": "panelGroup.13.0.4"
+          },
+          {
+            "source": "panelGroup.13.0.4",
+            "target": "panelGroup.13.0.5"
+          },
+          {
+            "source": "panelGroup.13.0.5",
+            "target": "panelGroup.13.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.40",
+        "label": "String 41",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.12"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.13.1.0",
+            "target": "panelGroup.13.1.1"
+          },
+          {
+            "source": "panelGroup.13.1.1",
+            "target": "panelGroup.13.1.2"
+          },
+          {
+            "source": "panelGroup.13.1.2",
+            "target": "panelGroup.13.1.3"
+          },
+          {
+            "source": "panelGroup.13.1.3",
+            "target": "panelGroup.13.1.4"
+          },
+          {
+            "source": "panelGroup.13.1.4",
+            "target": "panelGroup.13.1.5"
+          },
+          {
+            "source": "panelGroup.13.1.5",
+            "target": "panelGroup.13.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.41",
+        "label": "String 42",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.13"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.13.2.0",
+            "target": "panelGroup.13.2.1"
+          },
+          {
+            "source": "panelGroup.13.2.1",
+            "target": "panelGroup.13.2.2"
+          },
+          {
+            "source": "panelGroup.13.2.2",
+            "target": "panelGroup.13.2.3"
+          },
+          {
+            "source": "panelGroup.13.2.3",
+            "target": "panelGroup.13.2.4"
+          },
+          {
+            "source": "panelGroup.13.2.4",
+            "target": "panelGroup.13.2.5"
+          },
+          {
+            "source": "panelGroup.13.2.5",
+            "target": "panelGroup.13.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.42",
+        "label": "String 43",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.0"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.14.0.0",
+            "target": "panelGroup.14.0.1"
+          },
+          {
+            "source": "panelGroup.14.0.1",
+            "target": "panelGroup.14.0.2"
+          },
+          {
+            "source": "panelGroup.14.0.2",
+            "target": "panelGroup.14.0.3"
+          },
+          {
+            "source": "panelGroup.14.0.3",
+            "target": "panelGroup.14.0.4"
+          },
+          {
+            "source": "panelGroup.14.0.4",
+            "target": "panelGroup.14.0.5"
+          },
+          {
+            "source": "panelGroup.14.0.5",
+            "target": "panelGroup.14.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.43",
+        "label": "String 44",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.1"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.14.1.0",
+            "target": "panelGroup.14.1.1"
+          },
+          {
+            "source": "panelGroup.14.1.1",
+            "target": "panelGroup.14.1.2"
+          },
+          {
+            "source": "panelGroup.14.1.2",
+            "target": "panelGroup.14.1.3"
+          },
+          {
+            "source": "panelGroup.14.1.3",
+            "target": "panelGroup.14.1.4"
+          },
+          {
+            "source": "panelGroup.14.1.4",
+            "target": "panelGroup.14.1.5"
+          },
+          {
+            "source": "panelGroup.14.1.5",
+            "target": "panelGroup.14.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.44",
+        "label": "String 45",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.2"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.14.2.0",
+            "target": "panelGroup.14.2.1"
+          },
+          {
+            "source": "panelGroup.14.2.1",
+            "target": "panelGroup.14.2.2"
+          },
+          {
+            "source": "panelGroup.14.2.2",
+            "target": "panelGroup.14.2.3"
+          },
+          {
+            "source": "panelGroup.14.2.3",
+            "target": "panelGroup.14.2.4"
+          },
+          {
+            "source": "panelGroup.14.2.4",
+            "target": "panelGroup.14.2.5"
+          },
+          {
+            "source": "panelGroup.14.2.5",
+            "target": "panelGroup.14.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.45",
+        "label": "String 46",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.3"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.15.0.0",
+            "target": "panelGroup.15.0.1"
+          },
+          {
+            "source": "panelGroup.15.0.1",
+            "target": "panelGroup.15.0.2"
+          },
+          {
+            "source": "panelGroup.15.0.2",
+            "target": "panelGroup.15.0.3"
+          },
+          {
+            "source": "panelGroup.15.0.3",
+            "target": "panelGroup.15.0.4"
+          },
+          {
+            "source": "panelGroup.15.0.4",
+            "target": "panelGroup.15.0.5"
+          },
+          {
+            "source": "panelGroup.15.0.5",
+            "target": "panelGroup.15.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.46",
+        "label": "String 47",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.4"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.15.1.0",
+            "target": "panelGroup.15.1.1"
+          },
+          {
+            "source": "panelGroup.15.1.1",
+            "target": "panelGroup.15.1.2"
+          },
+          {
+            "source": "panelGroup.15.1.2",
+            "target": "panelGroup.15.1.3"
+          },
+          {
+            "source": "panelGroup.15.1.3",
+            "target": "panelGroup.15.1.4"
+          },
+          {
+            "source": "panelGroup.15.1.4",
+            "target": "panelGroup.15.1.5"
+          },
+          {
+            "source": "panelGroup.15.1.5",
+            "target": "panelGroup.15.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.47",
+        "label": "String 48",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.5"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.15.2.0",
+            "target": "panelGroup.15.2.1"
+          },
+          {
+            "source": "panelGroup.15.2.1",
+            "target": "panelGroup.15.2.2"
+          },
+          {
+            "source": "panelGroup.15.2.2",
+            "target": "panelGroup.15.2.3"
+          },
+          {
+            "source": "panelGroup.15.2.3",
+            "target": "panelGroup.15.2.4"
+          },
+          {
+            "source": "panelGroup.15.2.4",
+            "target": "panelGroup.15.2.5"
+          },
+          {
+            "source": "panelGroup.15.2.5",
+            "target": "panelGroup.15.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.48",
+        "label": "String 49",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.6"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.16.0.0",
+            "target": "panelGroup.16.0.1"
+          },
+          {
+            "source": "panelGroup.16.0.1",
+            "target": "panelGroup.16.0.2"
+          },
+          {
+            "source": "panelGroup.16.0.2",
+            "target": "panelGroup.16.0.3"
+          },
+          {
+            "source": "panelGroup.16.0.3",
+            "target": "panelGroup.16.0.4"
+          },
+          {
+            "source": "panelGroup.16.0.4",
+            "target": "panelGroup.16.0.5"
+          },
+          {
+            "source": "panelGroup.16.0.5",
+            "target": "panelGroup.16.0.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.49",
+        "label": "String 50",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.7"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.16.1.0",
+            "target": "panelGroup.16.1.1"
+          },
+          {
+            "source": "panelGroup.16.1.1",
+            "target": "panelGroup.16.1.2"
+          },
+          {
+            "source": "panelGroup.16.1.2",
+            "target": "panelGroup.16.1.3"
+          },
+          {
+            "source": "panelGroup.16.1.3",
+            "target": "panelGroup.16.1.4"
+          },
+          {
+            "source": "panelGroup.16.1.4",
+            "target": "panelGroup.16.1.5"
+          },
+          {
+            "source": "panelGroup.16.1.5",
+            "target": "panelGroup.16.1.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.50",
+        "label": "String 51",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.8"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.16.2.0",
+            "target": "panelGroup.16.2.1"
+          },
+          {
+            "source": "panelGroup.16.2.1",
+            "target": "panelGroup.16.2.2"
+          },
+          {
+            "source": "panelGroup.16.2.2",
+            "target": "panelGroup.16.2.3"
+          },
+          {
+            "source": "panelGroup.16.2.3",
+            "target": "panelGroup.16.2.4"
+          },
+          {
+            "source": "panelGroup.16.2.4",
+            "target": "panelGroup.16.2.5"
+          },
+          {
+            "source": "panelGroup.16.2.5",
+            "target": "panelGroup.16.2.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.51",
+        "label": "String 52",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.9"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.17.0.0",
+            "target": "panelGroup.17.0.1"
+          },
+          {
+            "source": "panelGroup.17.0.1",
+            "target": "panelGroup.17.0.2"
+          },
+          {
+            "source": "panelGroup.17.0.2",
+            "target": "panelGroup.17.0.3"
+          },
+          {
+            "source": "panelGroup.17.0.3",
+            "target": "panelGroup.17.0.4"
+          },
+          {
+            "source": "panelGroup.17.0.4",
+            "target": "panelGroup.17.0.5"
+          },
+          {
+            "source": "panelGroup.17.0.5",
+            "target": "panelGroup.17.0.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.52",
+        "label": "String 53",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.10"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.17.1.0",
+            "target": "panelGroup.17.1.1"
+          },
+          {
+            "source": "panelGroup.17.1.1",
+            "target": "panelGroup.17.1.2"
+          },
+          {
+            "source": "panelGroup.17.1.2",
+            "target": "panelGroup.17.1.3"
+          },
+          {
+            "source": "panelGroup.17.1.3",
+            "target": "panelGroup.17.1.4"
+          },
+          {
+            "source": "panelGroup.17.1.4",
+            "target": "panelGroup.17.1.5"
+          },
+          {
+            "source": "panelGroup.17.1.5",
+            "target": "panelGroup.17.1.6"
+          }
+        ],
+        "style": {
+          "color": "#9333ea",
+          "width": 3,
+          "cap": "round",
+          "join": "round"
+        }
+      },
+      {
+        "type": "relations",
+        "id": "string.53",
+        "label": "String 54",
+        "attrs": {
+          "x": 0,
+          "y": 0,
+          "display": "string",
+          "metadata": {
+            "parent": "inverter.11"
+          }
+        },
+        "links": [
+          {
+            "source": "panelGroup.17.2.0",
+            "target": "panelGroup.17.2.1"
+          },
+          {
+            "source": "panelGroup.17.2.1",
+            "target": "panelGroup.17.2.2"
+          },
+          {
+            "source": "panelGroup.17.2.2",
+            "target": "panelGroup.17.2.3"
+          },
+          {
+            "source": "panelGroup.17.2.3",
+            "target": "panelGroup.17.2.4"
+          },
+          {
+            "source": "panelGroup.17.2.4",
+            "target": "panelGroup.17.2.5"
+          },
+          {
+            "source": "panelGroup.17.2.5",
+            "target": "panelGroup.17.2.6"
+          }
+        ],
+        "style": {
+          "color": "#2563eb",
+          "width": 4,
+          "cap": "round",
+          "join": "round"
+        }
+      }
+    ]
+  }
+]

--- a/src/tests/perf/draw.bench.js
+++ b/src/tests/perf/draw.bench.js
@@ -1,0 +1,720 @@
+import { afterAll, bench, describe } from 'vitest';
+import { Patchmap } from '../../patchmap';
+import drawBenchData from './draw-data.json';
+
+const BENCH_OPTIONS = {
+  warmupIterations: 0,
+  warmupTime: 0,
+  iterations: 5,
+  time: 80,
+};
+const FAST_PATH_DISABLE_FLAG = '__PATCHMAP_DISABLE_INITIAL_FAST_PATH__';
+const VISIBLE_SAMPLE_LOG_LIMIT = 12;
+
+const describeInBrowser =
+  typeof document !== 'undefined' ? describe : describe.skip;
+
+const PATCH_SERVICE_FIT_OPTIONS = {
+  filter: (obj) => obj.type !== 'image',
+  padding: { y: 160 },
+};
+
+const countDataNodes = (nodes) => {
+  let count = 0;
+  const stack = Array.isArray(nodes) ? [...nodes] : [nodes];
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || typeof node !== 'object') continue;
+
+    count += 1;
+    if (Array.isArray(node.children)) stack.push(...node.children);
+  }
+
+  return count;
+};
+
+const getJsonSizeBytes = (data) =>
+  new TextEncoder().encode(JSON.stringify(data)).length;
+
+const assertDrawableData = (data) => {
+  if (!Array.isArray(data)) {
+    throw new TypeError('draw-data.json must export a top-level array.');
+  }
+};
+
+const waitForPostrender = (app, timeoutMs = 30_000) =>
+  new Promise((resolve, reject) => {
+    const listener = {
+      postrender: () => {
+        clearTimeout(timeoutId);
+        app.renderer.runners.postrender.remove(listener);
+        resolve(performance.now());
+      },
+    };
+    const timeoutId = setTimeout(() => {
+      app.renderer.runners.postrender.remove(listener);
+      reject(
+        new Error(`Timed out waiting for postrender after ${timeoutMs}ms.`),
+      );
+    }, timeoutMs);
+
+    app.renderer.runners.postrender.add(listener);
+  });
+
+const waitForAnimationFrame = () =>
+  new Promise((resolve) => {
+    requestAnimationFrame(() => resolve(performance.now()));
+  });
+
+const waitForVisibleFrame = async (app) => {
+  const renderedAt = await waitForPostrender(app);
+  const visibleAt = await waitForAnimationFrame();
+
+  return { renderedAt, visibleAt };
+};
+
+const waitForPatchmapDraw = (patchmap, timeoutMs = 30_000) =>
+  new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      patchmap.off('patchmap:draw', onDraw);
+      reject(
+        new Error(`Timed out waiting for patchmap:draw after ${timeoutMs}ms.`),
+      );
+    }, timeoutMs);
+    const onDraw = () => {
+      clearTimeout(timeoutId);
+      resolve(performance.now());
+    };
+    patchmap.once('patchmap:draw', onDraw);
+  });
+
+const roundMetric = (value) => Number(value.toFixed(2));
+
+const toLoggableSample = (sample) => ({
+  label: sample.label,
+  sample: sample.sample,
+  drawMs: roundMetric(sample.drawMs),
+  readyWaitMs:
+    sample.readyWaitMs == null ? undefined : roundMetric(sample.readyWaitMs),
+  renderWaitMs: roundMetric(sample.renderWaitMs),
+  visibleWaitMs: roundMetric(sample.visibleWaitMs),
+  totalMs: roundMetric(sample.totalMs),
+  patchServiceSyncCount: sample.patchServiceSyncCount,
+  patchServiceSyncMs:
+    sample.patchServiceSyncMs == null
+      ? undefined
+      : roundMetric(sample.patchServiceSyncMs),
+  reportPanelUpdateCount: sample.reportPanelUpdateCount,
+  reportPanelUpdateMs:
+    sample.reportPanelUpdateMs == null
+      ? undefined
+      : roundMetric(sample.reportPanelUpdateMs),
+});
+
+const summarizeSamples = (samples) => {
+  const byLabel = new Map();
+
+  for (const sample of samples) {
+    const current = byLabel.get(sample.label) ?? {
+      label: sample.label,
+      samples: 0,
+      drawMs: 0,
+      readyWaitMs: 0,
+      renderWaitMs: 0,
+      visibleWaitMs: 0,
+      totalMs: 0,
+      patchServiceSyncMs: 0,
+      reportPanelUpdateMs: 0,
+    };
+
+    current.samples += 1;
+    current.drawMs += sample.drawMs;
+    current.readyWaitMs += sample.readyWaitMs ?? 0;
+    current.renderWaitMs += sample.renderWaitMs;
+    current.visibleWaitMs += sample.visibleWaitMs;
+    current.totalMs += sample.totalMs;
+    current.patchServiceSyncMs += sample.patchServiceSyncMs ?? 0;
+    current.reportPanelUpdateMs += sample.reportPanelUpdateMs ?? 0;
+    byLabel.set(sample.label, current);
+  }
+
+  return [...byLabel.values()].map((summary) => ({
+    label: summary.label,
+    samples: summary.samples,
+    drawMeanMs: Number((summary.drawMs / summary.samples).toFixed(2)),
+    readyWaitMeanMs: Number((summary.readyWaitMs / summary.samples).toFixed(2)),
+    renderWaitMeanMs: Number(
+      (summary.renderWaitMs / summary.samples).toFixed(2),
+    ),
+    visibleWaitMeanMs: Number(
+      (summary.visibleWaitMs / summary.samples).toFixed(2),
+    ),
+    totalMeanMs: Number((summary.totalMs / summary.samples).toFixed(2)),
+    patchServiceSyncMeanMs: Number(
+      (summary.patchServiceSyncMs / summary.samples).toFixed(2),
+    ),
+    reportPanelUpdateMeanMs: Number(
+      (summary.reportPanelUpdateMs / summary.samples).toFixed(2),
+    ),
+  }));
+};
+
+const summarizeInitialDrawSamples = (samples) => {
+  const byLabel = new Map();
+
+  for (const sample of samples) {
+    const current = byLabel.get(sample.label) ?? {
+      label: sample.label,
+      samples: 0,
+      drawMs: 0,
+    };
+    current.samples += 1;
+    current.drawMs += sample.drawMs;
+    byLabel.set(sample.label, current);
+  }
+
+  return [...byLabel.values()].map((summary) => ({
+    label: summary.label,
+    samples: summary.samples,
+    drawMeanMs: Number((summary.drawMs / summary.samples).toFixed(2)),
+  }));
+};
+
+const flattenElements = (value) => {
+  if (!Array.isArray(value)) return value ? [value] : [];
+  return value.flatMap((item) => (Array.isArray(item) ? item : [item]));
+};
+
+const pushChildren = (stack, target) => {
+  if (!Array.isArray(target?.children) || target.children.length === 0) return;
+  stack.push(...target.children);
+};
+
+const createItemElementMap = (children) => {
+  const itemElementMap = new Map();
+  const stack = [...children];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+
+    if (current.type === 'item' && current.id) {
+      itemElementMap.set(current.id, current);
+    }
+    pushChildren(stack, current);
+  }
+  return itemElementMap;
+};
+
+const createPatchServiceSync = (context) => {
+  const { patchmap } = context;
+  context.patchServiceStats = {
+    children: [],
+    itemElementMap: new Map(),
+    syncCount: 0,
+    syncMs: 0,
+    reportPanelUpdateCount: 0,
+    reportPanelUpdateMs: 0,
+  };
+  const sync = () => {
+    const startedAt = performance.now();
+    context.patchServiceStats.children = [...patchmap.world.children];
+    context.patchServiceStats.itemElementMap = createItemElementMap(
+      context.patchServiceStats.children,
+    );
+    context.patchServiceStats.syncCount += 1;
+    context.patchServiceStats.syncMs += performance.now() - startedAt;
+  };
+  patchmap.on('patchmap:draw', sync);
+  patchmap.on('patchmap:updated', sync);
+  return context.patchServiceStats;
+};
+
+const hideRelations = (patchmap) => {
+  patchmap.update({
+    path: '$..children[?(@.type==="relations")]',
+    changes: { show: false },
+  });
+};
+
+const hideInactiveGridCells = (patchmap) => {
+  patchmap.update({
+    path: '$..children[?(@.type==="grid")]',
+    changes: { inactiveCellStrategy: 'hide' },
+  });
+};
+
+const updateReportPanelBackgrounds = (context) => {
+  const { patchmap } = context;
+  const startedAt = performance.now();
+  let updatedCount = 0;
+  const panels = flattenElements(
+    patchmap.selector('$..children[?(@.type=="grid")].children', {}),
+  );
+
+  for (const panel of panels) {
+    if (!panel || panel.type !== 'item') continue;
+    const hash = hashString(panel.id);
+    patchmap.update({
+      elements: panel,
+      changes: {
+        components: [
+          {
+            type: 'background',
+            source: {
+              type: 'rect',
+              fill: hashToPanelColor(hash),
+              borderWidth: 2,
+            },
+          },
+        ],
+      },
+    });
+    updatedCount += 1;
+  }
+  context.patchServiceStats.reportPanelUpdateCount += updatedCount;
+  context.patchServiceStats.reportPanelUpdateMs +=
+    performance.now() - startedAt;
+};
+
+const hashString = (value) => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+};
+
+const hashToPanelColor = (hash) => {
+  const score = hash % 5;
+  if (score <= 1) return '#ef4444';
+  if (score === 2) return '#f59e0b';
+  if (score === 3) return '#84cc16';
+  return '#22c55e';
+};
+
+describeInBrowser('perf: patchmap.draw', () => {
+  const contexts = new Map();
+  const initialDrawSamples = [];
+  const visibleSamples = [];
+  const loggedContexts = new Set();
+
+  const createContext = async (name, configure) => {
+    assertDrawableData(drawBenchData);
+
+    const hostElement = document.createElement('div');
+    hostElement.style.width = '100vw';
+    hostElement.style.height = '100vh';
+    document.body.appendChild(hostElement);
+
+    const patchmap = new Patchmap();
+    await patchmap.init(hostElement);
+    const context = { name, patchmap, hostElement };
+    configure?.(context);
+    return context;
+  };
+
+  const getContext = async (name, configure) => {
+    const existing = contexts.get(name);
+    if (existing) return existing;
+
+    const context = await createContext(name, configure);
+    contexts.set(name, context);
+
+    await drawAndWaitForVisible(context, () => {
+      context.patchmap.draw(drawBenchData);
+    });
+
+    console.info('[draw bench context]', {
+      scenario: name,
+      topLevelItems: drawBenchData.length,
+      dataNodes: countDataNodes(drawBenchData),
+      jsonSizeBytes: getJsonSizeBytes(drawBenchData),
+      benchOptions: BENCH_OPTIONS,
+      dataSource: 'src/tests/perf/draw-data.json',
+    });
+
+    return context;
+  };
+
+  const cleanupContext = (context) => {
+    if (!context) return;
+    contexts.delete(context.name);
+    context.patchmap.destroy();
+    if (context.hostElement?.parentElement) {
+      context.hostElement.parentElement.removeChild(context.hostElement);
+    }
+  };
+
+  const logBenchContext = (name) => {
+    if (loggedContexts.has(name)) return;
+    loggedContexts.add(name);
+    console.info('[draw bench context]', {
+      scenario: name,
+      topLevelItems: drawBenchData.length,
+      dataNodes: countDataNodes(drawBenchData),
+      jsonSizeBytes: getJsonSizeBytes(drawBenchData),
+      benchOptions: BENCH_OPTIONS,
+      dataSource: 'src/tests/perf/draw-data.json',
+    });
+  };
+
+  const drawAndWaitForVisible = async (context, drawAction) => {
+    const visibleFrame = waitForVisibleFrame(context.patchmap.app);
+    drawAction();
+    await visibleFrame;
+  };
+
+  const measureDrawToVisible = async (label, context, drawAction) => {
+    const startedAt = performance.now();
+
+    drawAction();
+
+    const drawReturnedAt = performance.now();
+    const visibleFrame = waitForVisibleFrame(context.patchmap.app);
+    const { renderedAt, visibleAt } = await visibleFrame;
+    const sample = {
+      label,
+      sample: visibleSamples.length + 1,
+      drawMs: drawReturnedAt - startedAt,
+      renderWaitMs: renderedAt - drawReturnedAt,
+      visibleWaitMs: visibleAt - drawReturnedAt,
+      totalMs: visibleAt - startedAt,
+    };
+    visibleSamples.push(sample);
+
+    if (visibleSamples.length <= VISIBLE_SAMPLE_LOG_LIMIT) {
+      console.info('[draw-to-visible sample]', toLoggableSample(sample));
+    }
+  };
+
+  const measureInitialDrawOnly = async (label, configure, drawAction) => {
+    const context = await createContext(label, configure);
+    try {
+      const startedAt = performance.now();
+      drawAction(context);
+      const drawReturnedAt = performance.now();
+      const sample = {
+        label,
+        sample: initialDrawSamples.length + 1,
+        drawMs: drawReturnedAt - startedAt,
+      };
+      initialDrawSamples.push(sample);
+
+      if (initialDrawSamples.length <= VISIBLE_SAMPLE_LOG_LIMIT) {
+        console.info('[initial-draw sample]', {
+          label: sample.label,
+          sample: sample.sample,
+          drawMs: roundMetric(sample.drawMs),
+        });
+      }
+    } finally {
+      cleanupContext(context);
+    }
+  };
+
+  const measurePatchServiceReady = async (label, context, drawAction) => {
+    const stats = context.patchServiceStats;
+    const syncCountBefore = stats?.syncCount ?? 0;
+    const syncMsBefore = stats?.syncMs ?? 0;
+    const reportPanelUpdateCountBefore = stats?.reportPanelUpdateCount ?? 0;
+    const reportPanelUpdateMsBefore = stats?.reportPanelUpdateMs ?? 0;
+    const startedAt = performance.now();
+    const drawEvent = waitForPatchmapDraw(context.patchmap);
+
+    drawAction();
+
+    const drawReturnedAt = performance.now();
+    const visibleFrame = waitForVisibleFrame(context.patchmap.app);
+    const drawEventAt = await drawEvent;
+    const { renderedAt, visibleAt } = await visibleFrame;
+    const sample = {
+      label,
+      sample: visibleSamples.length + 1,
+      drawMs: drawReturnedAt - startedAt,
+      readyWaitMs: drawEventAt - drawReturnedAt,
+      renderWaitMs: renderedAt - drawReturnedAt,
+      visibleWaitMs: visibleAt - drawReturnedAt,
+      totalMs: visibleAt - startedAt,
+      patchServiceSyncCount: (stats?.syncCount ?? 0) - syncCountBefore,
+      patchServiceSyncMs: (stats?.syncMs ?? 0) - syncMsBefore,
+      reportPanelUpdateCount:
+        (stats?.reportPanelUpdateCount ?? 0) - reportPanelUpdateCountBefore,
+      reportPanelUpdateMs:
+        (stats?.reportPanelUpdateMs ?? 0) - reportPanelUpdateMsBefore,
+    };
+    visibleSamples.push(sample);
+
+    if (visibleSamples.length <= VISIBLE_SAMPLE_LOG_LIMIT) {
+      console.info('[patch-service-ready sample]', toLoggableSample(sample));
+    }
+  };
+
+  const setupCore = async () => getContext('core draw only');
+  const setupCoreInitial = () => logBenchContext('core initial draw only');
+  const setupCoreInitialBaseline = () => {
+    globalThis[FAST_PATH_DISABLE_FLAG] = true;
+    logBenchContext('core initial draw baseline');
+  };
+  const setupCoreInitialFastPath = () => {
+    globalThis[FAST_PATH_DISABLE_FLAG] = false;
+    logBenchContext('core initial draw fast path');
+  };
+  const setupCoreInitialVisible = () =>
+    logBenchContext('core initial draw-to-visible');
+
+  const setupPatchServiceEditor = async () =>
+    getContext('patch-service editor', (context) => {
+      createPatchServiceSync(context);
+      context.patchmap.on('patchmap:draw', () => {
+        hideInactiveGridCells(context.patchmap);
+      });
+    });
+  const setupPatchServiceEditorInitial = async () =>
+    logBenchContext('patch-service editor initial draw');
+  const configurePatchServiceEditor = (context) => {
+    createPatchServiceSync(context);
+    context.patchmap.on('patchmap:draw', () => {
+      hideInactiveGridCells(context.patchmap);
+    });
+  };
+
+  const setupPatchServiceDashboard = async () =>
+    getContext('patch-service dashboard widget', (context) => {
+      createPatchServiceSync(context);
+      context.patchmap.on('patchmap:draw', () => {
+        hideRelations(context.patchmap);
+      });
+    });
+  const setupPatchServiceDashboardInitial = async () =>
+    logBenchContext('patch-service dashboard initial draw');
+  const configurePatchServiceDashboard = (context) => {
+    createPatchServiceSync(context);
+    context.patchmap.on('patchmap:draw', () => {
+      hideRelations(context.patchmap);
+    });
+  };
+
+  const setupPatchServiceReport = async () =>
+    getContext('patch-service report panel-performance', (context) => {
+      createPatchServiceSync(context);
+      context.patchmap.on('patchmap:draw', () => {
+        updateReportPanelBackgrounds(context);
+      });
+    });
+
+  afterAll(() => {
+    globalThis[FAST_PATH_DISABLE_FLAG] = false;
+    if (initialDrawSamples.length > 0) {
+      console.info(
+        '[initial-draw summary]',
+        summarizeInitialDrawSamples(initialDrawSamples),
+      );
+    }
+    if (visibleSamples.length > 0) {
+      console.info(
+        '[draw-to-visible summary]',
+        summarizeSamples(visibleSamples),
+      );
+    }
+    for (const context of contexts.values()) {
+      context.patchmap.destroy();
+      if (context.hostElement?.parentElement) {
+        context.hostElement.parentElement.removeChild(context.hostElement);
+      }
+    }
+  });
+
+  bench(
+    'core initial draw baseline',
+    async () => {
+      await measureInitialDrawOnly(
+        'core initial draw baseline',
+        undefined,
+        (context) => {
+          context.patchmap.draw(drawBenchData);
+        },
+      );
+    },
+    { ...BENCH_OPTIONS, setup: setupCoreInitialBaseline },
+  );
+
+  bench(
+    'core initial draw fast path',
+    async () => {
+      await measureInitialDrawOnly(
+        'core initial draw fast path',
+        undefined,
+        (context) => {
+          context.patchmap.draw(drawBenchData);
+        },
+      );
+    },
+    { ...BENCH_OPTIONS, setup: setupCoreInitialFastPath },
+  );
+
+  bench(
+    'core initial draw',
+    async () => {
+      await measureInitialDrawOnly(
+        'core initial draw',
+        undefined,
+        (context) => {
+          context.patchmap.draw(drawBenchData);
+        },
+      );
+    },
+    { ...BENCH_OPTIONS, setup: setupCoreInitial },
+  );
+
+  bench(
+    'core initial draw-to-visible',
+    async () => {
+      const context = await createContext('core initial draw-to-visible');
+      try {
+        await measureDrawToVisible('core initial draw', context, () => {
+          context.patchmap.draw(drawBenchData);
+        });
+      } finally {
+        cleanupContext(context);
+      }
+    },
+    { ...BENCH_OPTIONS, setup: setupCoreInitialVisible },
+  );
+
+  bench(
+    'patch-service editor ready: initial draw',
+    async () => {
+      const context = await createContext(
+        'patch-service editor initial draw',
+        configurePatchServiceEditor,
+      );
+      try {
+        await measurePatchServiceReady(
+          'patch-service editor initial draw',
+          context,
+          () => {
+            context.patchmap.draw(drawBenchData);
+            context.patchmap.fit(null, PATCH_SERVICE_FIT_OPTIONS);
+          },
+        );
+      } finally {
+        cleanupContext(context);
+      }
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchServiceEditorInitial },
+  );
+
+  bench(
+    'patch-service dashboard ready: initial draw',
+    async () => {
+      const context = await createContext(
+        'patch-service dashboard initial draw',
+        configurePatchServiceDashboard,
+      );
+      try {
+        await measurePatchServiceReady(
+          'patch-service dashboard initial draw',
+          context,
+          () => {
+            context.patchmap.draw(drawBenchData);
+            context.patchmap.fit(null, PATCH_SERVICE_FIT_OPTIONS);
+          },
+        );
+      } finally {
+        cleanupContext(context);
+      }
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchServiceDashboardInitial },
+  );
+
+  bench(
+    'core draw: redraw same data',
+    () => {
+      const { patchmap } = contexts.get('core draw only');
+      patchmap.draw(drawBenchData);
+    },
+    { ...BENCH_OPTIONS, setup: setupCore },
+  );
+
+  bench(
+    'core draw-to-visible: redraw same data',
+    async () => {
+      const context = contexts.get('core draw only');
+      await measureDrawToVisible('core redraw same data', context, () => {
+        context.patchmap.draw(drawBenchData);
+      });
+    },
+    { ...BENCH_OPTIONS, setup: setupCore },
+  );
+
+  bench(
+    'patch-service editor ready: initial-like redraw',
+    async () => {
+      const context = contexts.get('patch-service editor');
+      await measurePatchServiceReady(
+        'patch-service editor initial-like redraw',
+        context,
+        () => {
+          context.patchmap.draw(drawBenchData);
+          context.patchmap.fit(null, PATCH_SERVICE_FIT_OPTIONS);
+        },
+      );
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchServiceEditor },
+  );
+
+  bench(
+    'patch-service dashboard ready: blueprint redraw',
+    async () => {
+      const context = contexts.get('patch-service dashboard widget');
+      await measurePatchServiceReady(
+        'patch-service dashboard blueprint redraw',
+        context,
+        () => {
+          context.patchmap.draw(drawBenchData);
+          context.patchmap.fit(null, PATCH_SERVICE_FIT_OPTIONS);
+        },
+      );
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchServiceDashboard },
+  );
+
+  bench(
+    'patch-service report ready: date redraw',
+    async () => {
+      const context = contexts.get('patch-service report panel-performance');
+      await measurePatchServiceReady(
+        'patch-service report date redraw',
+        context,
+        () => {
+          context.patchmap.draw(drawBenchData);
+          context.patchmap.fit(null, PATCH_SERVICE_FIT_OPTIONS);
+        },
+      );
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchServiceReport },
+  );
+
+  bench(
+    'core draw: clear then draw data',
+    () => {
+      const { patchmap } = contexts.get('core draw only');
+      patchmap.draw([]);
+      patchmap.draw(drawBenchData);
+    },
+    { ...BENCH_OPTIONS, setup: setupCore },
+  );
+
+  bench(
+    'core draw-to-visible: clear then draw data',
+    async () => {
+      const context = contexts.get('core draw only');
+      await measureDrawToVisible('core clear then draw data', context, () => {
+        context.patchmap.draw([]);
+        context.patchmap.draw(drawBenchData);
+      });
+    },
+    { ...BENCH_OPTIONS, setup: setupCore },
+  );
+});

--- a/src/tests/perf/update.bench.js
+++ b/src/tests/perf/update.bench.js
@@ -1,9 +1,7 @@
-import { bench, describe } from 'vitest';
+import { afterAll, bench, describe } from 'vitest';
 import { Patchmap } from '../../patchmap';
-import { benchData } from './data';
+import drawBenchData from './draw-data.json';
 
-const itemsSelector = '$..[?(@.display=="panelGroup")].children';
-const MAX_ITEMS = 1000;
 const BENCH_OPTIONS = {
   warmupIterations: 0,
   warmupTime: 20,
@@ -11,190 +9,338 @@ const BENCH_OPTIONS = {
   time: 80,
 };
 
-const ITEM_APPLY_OPTIONS = { mergeStrategy: 'merge', refresh: false };
-const BOOLEAN_OPTIONS = [false, true];
-const APPLY_OPTION_MATRIX = BOOLEAN_OPTIONS.flatMap((refresh) =>
-  BOOLEAN_OPTIONS.flatMap((validateSchema) =>
-    BOOLEAN_OPTIONS.map((normalize) => ({
-      mergeStrategy: 'merge',
-      refresh,
-      validateSchema,
-      normalize,
-    })),
-  ),
-);
-
-const createItemBarOnlyPatch = (percent, tint) => ({
-  components: [
-    {
-      type: 'bar',
-      show: true,
-      size: { height: `${percent}%` },
-      tint,
-      animation: true,
-    },
-  ],
-});
-
-const createBarPatch = (percent, tint) => ({
-  show: true,
-  size: { height: { value: percent, unit: '%' } },
-  tint,
-  animation: true,
-});
-
-const createMatrixLabel = (options) => {
-  return `refresh=${String(options.refresh)}, validate=${String(options.validateSchema)}, normalize=${String(options.normalize)}`;
-};
+const PANEL_ITEM_SELECTOR = '$..children[?(@.display=="panelGroup")].children';
+const ALL_ITEM_SELECTOR = '$..children[?(@.type==="item")]';
 
 const describeInBrowser =
   typeof document !== 'undefined' ? describe : describe.skip;
 
-describeInBrowser(
-  'perf: update hot path (item components vs bar direct apply)',
-  () => {
-    let patchmap;
-    let hostElement;
-    let items = [];
-    let bars = [];
-    let updateItemBarOptionsA = [];
-    let updateItemBarOptionsB = [];
-    let itemBarOnlyChangesA = [];
-    let itemBarOnlyChangesB = [];
-    let barChangesA = [];
-    let barChangesB = [];
-    let isPrepared = false;
+const flattenElements = (value) => {
+  if (!Array.isArray(value)) return value ? [value] : [];
+  return value.flatMap((item) => (Array.isArray(item) ? item : [item]));
+};
 
-    const runPatchmapUpdate = (optionsList) => {
-      for (let i = 0; i < optionsList.length; i += 1) {
-        patchmap.update(optionsList[i]);
-      }
-    };
+const assertDrawableData = (data) => {
+  if (!Array.isArray(data)) {
+    throw new TypeError('draw-data.json must export a top-level array.');
+  }
+};
 
-    const runItemApply = (changesList) => {
-      for (let i = 0; i < items.length; i += 1) {
-        items[i].apply(changesList[i], ITEM_APPLY_OPTIONS);
-      }
-    };
+const getJsonSizeBytes = (data) =>
+  new TextEncoder().encode(JSON.stringify(data)).length;
 
-    const runBarApply = (changesList, options) => {
-      for (let i = 0; i < bars.length; i += 1) {
-        const bar = bars[i];
-        if (!bar) continue;
-        bar.apply(changesList[i], options);
-      }
-    };
+const countDataNodes = (nodes) => {
+  let count = 0;
+  const stack = Array.isArray(nodes) ? [...nodes] : [nodes];
 
-    const setupCycle = async () => {
-      if (isPrepared) return;
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node || typeof node !== 'object') continue;
 
-      document.body.innerHTML = '';
-      hostElement = document.createElement('div');
-      hostElement.style.height = '100svh';
-      document.body.appendChild(hostElement);
+    count += 1;
+    if (Array.isArray(node.children)) stack.push(...node.children);
+  }
 
-      patchmap = new Patchmap();
-      await patchmap.init(hostElement);
-      patchmap.draw(benchData);
+  return count;
+};
 
-      const selectedItems = patchmap
-        .selector(itemsSelector)
-        .slice(0, MAX_ITEMS);
-      items = selectedItems.filter((item) =>
-        item.children.some((child) => child.type === 'bar'),
-      );
-      bars = items.map((item) =>
-        item.children.find((child) => child.type === 'bar'),
-      );
-
-      itemBarOnlyChangesA = items.map((_, i) =>
-        createItemBarOnlyPatch(
-          i % 2 ? 70 : 30,
-          i % 2 ? 'primary.default' : 'primary.dark',
-        ),
-      );
-      itemBarOnlyChangesB = items.map((_, i) =>
-        createItemBarOnlyPatch(
-          i % 2 ? 30 : 70,
-          i % 2 ? 'primary.dark' : 'primary.default',
-        ),
-      );
-
-      barChangesA = bars.map((_, i) =>
-        createBarPatch(
-          i % 2 ? 70 : 30,
-          i % 2 ? 'primary.default' : 'primary.dark',
-        ),
-      );
-      barChangesB = bars.map((_, i) =>
-        createBarPatch(
-          i % 2 ? 30 : 70,
-          i % 2 ? 'primary.dark' : 'primary.default',
-        ),
-      );
-
-      updateItemBarOptionsA = items.map((item, i) => ({
-        elements: item,
-        changes: itemBarOnlyChangesA[i],
-        emit: false, // Compare core update path without event dispatch overhead.
-      }));
-      updateItemBarOptionsB = items.map((item, i) => ({
-        elements: item,
-        changes: itemBarOnlyChangesB[i],
-        emit: false, // Compare core update path without event dispatch overhead.
-      }));
-
-      runPatchmapUpdate(updateItemBarOptionsA);
-      runPatchmapUpdate(updateItemBarOptionsB);
-
-      console.info('[bench context]', {
-        selectedItems: selectedItems.length,
-        sampledItems: items.length,
-        bars: bars.length,
-        benchOptions: BENCH_OPTIONS,
-      });
-      isPrepared = true;
-    };
-
-    const teardownCycle = () => {};
-
-    bench(
-      'B1: patchmap.update per-item item.components (bar-only)',
-      () => {
-        runPatchmapUpdate(updateItemBarOptionsA);
-        runPatchmapUpdate(updateItemBarOptionsB);
+const panelInitChanges = () => ({
+  components: [
+    { type: 'bar', animation: false },
+    {
+      type: 'text',
+      text: '',
+      style: {
+        fontWeight: '600',
+        fontSize: 'auto',
+        autoFont: { min: 8, max: 14 },
+        align: 'center',
+        fill: 'white',
+        breakWords: true,
+        wordWrapWidth: 'auto',
       },
-      { ...BENCH_OPTIONS, setup: setupCycle, teardown: teardownCycle },
-    );
+      margin: 4,
+    },
+    { type: 'icon', show: true, size: 20, source: 'loading', tint: 'black' },
+  ],
+});
 
-    bench(
-      'B2: item.apply per-item item.components (bar-only)',
-      () => {
-        runItemApply(itemBarOnlyChangesA);
-        runItemApply(itemBarOnlyChangesB);
+const panelChartChanges = (index, variant) => {
+  const high = (index + variant) % 2 === 0;
+  const percent = high ? 76 : 31;
+  const tint = high ? 'primary.default' : 'primary.dark';
+  return {
+    components: [
+      {
+        type: 'bar',
+        show: true,
+        size: { height: `${percent}%` },
+        tint,
+        animation: true,
       },
-      { ...BENCH_OPTIONS, setup: setupCycle, teardown: teardownCycle },
-    );
+      { type: 'icon', show: false },
+      { type: 'text', show: false },
+    ],
+  };
+};
 
-    bench(
-      'B3: bar.apply per-item direct bar (baseline options)',
-      () => {
-        runBarApply(barChangesA, ITEM_APPLY_OPTIONS);
-        runBarApply(barChangesB, ITEM_APPLY_OPTIONS);
+const panelTextChanges = (index, variant) => {
+  const tint = (index + variant) % 3 === 0 ? '#f59e0b' : '#22c55e';
+  return {
+    components: [
+      { type: 'bar', show: true, size: '100%', tint, animation: false },
+      { type: 'icon', show: false },
+      {
+        type: 'text',
+        show: true,
+        text: `${(index + 1) * (variant + 1)}\nW`,
+        style: { fill: 'white' },
       },
-      { ...BENCH_OPTIONS, setup: setupCycle, teardown: teardownCycle },
-    );
+    ],
+  };
+};
 
-    for (const options of APPLY_OPTION_MATRIX) {
-      const label = createMatrixLabel(options);
-      bench(
-        `S6 matrix: bar.apply (${label})`,
-        () => {
-          runBarApply(barChangesA, options);
-          runBarApply(barChangesB, options);
+const panelMixedChanges = (index, variant) => {
+  if (index % 11 === 0) {
+    return {
+      components: [
+        {
+          type: 'bar',
+          show: true,
+          size: '100%',
+          tint: 'gray.dark',
+          animation: false,
         },
-        { ...BENCH_OPTIONS, setup: setupCycle, teardown: teardownCycle },
-      );
+        { type: 'icon', show: true, source: 'warning', tint: 'white' },
+        { type: 'text', show: false },
+      ],
+    };
+  }
+  if (index % 17 === 0) {
+    return {
+      components: [
+        {
+          type: 'bar',
+          show: true,
+          size: '100%',
+          tint: 'gray.light',
+          animation: false,
+        },
+        { type: 'icon', show: true, source: 'wifi', tint: 'white' },
+        { type: 'text', show: false },
+      ],
+    };
+  }
+  return index % 5 === 0
+    ? panelTextChanges(index, variant)
+    : panelChartChanges(index, variant);
+};
+
+const createChangesList = (items, factory, variant) =>
+  items.map((_, index) => factory(index, variant));
+
+describeInBrowser('perf: patchmap.update dashboard plant-map', () => {
+  let patchmap;
+  let hostElement;
+  let panelItems = [];
+  let allItems = [];
+  let panelInitA;
+  let panelInitB;
+  let panelChartA = [];
+  let panelChartB = [];
+  let panelMixedA = [];
+  let panelMixedB = [];
+  let isPrepared = false;
+
+  const setupPatchmap = async () => {
+    if (isPrepared) return;
+    assertDrawableData(drawBenchData);
+
+    document.body.innerHTML = '';
+    hostElement = document.createElement('div');
+    hostElement.style.width = '100vw';
+    hostElement.style.height = '100vh';
+    document.body.appendChild(hostElement);
+
+    patchmap = new Patchmap();
+    await patchmap.init(hostElement);
+    patchmap.draw(drawBenchData);
+
+    panelItems = flattenElements(patchmap.selector(PANEL_ITEM_SELECTOR)).filter(
+      (item) => item?.type === 'item',
+    );
+    allItems = flattenElements(patchmap.selector(ALL_ITEM_SELECTOR)).filter(
+      (item) => item?.type === 'item',
+    );
+
+    panelInitA = panelInitChanges();
+    panelInitB = {
+      components: [
+        { type: 'bar', show: false },
+        { type: 'icon', show: true, source: 'loading', tint: 'black' },
+      ],
+    };
+    panelChartA = createChangesList(panelItems, panelChartChanges, 0);
+    panelChartB = createChangesList(panelItems, panelChartChanges, 1);
+    panelMixedA = createChangesList(panelItems, panelMixedChanges, 0);
+    panelMixedB = createChangesList(panelItems, panelMixedChanges, 1);
+
+    runPanelInitUpdate(panelInitA);
+    runPanelInitUpdate(panelInitB);
+    runPanelPerItemUpdate(panelChartA);
+    runPanelPerItemUpdate(panelChartB);
+
+    console.info('[update bench context]', {
+      scenario: 'dashboard plant-map',
+      topLevelItems: drawBenchData.length,
+      dataNodes: countDataNodes(drawBenchData),
+      jsonSizeBytes: getJsonSizeBytes(drawBenchData),
+      panelItems: panelItems.length,
+      allItems: allItems.length,
+      benchOptions: BENCH_OPTIONS,
+      dataSource: 'src/tests/perf/draw-data.json',
+      patchServiceUsage: [
+        'objectState: per item patchmap.update({ elements: item, validateSchema: false, emit: false })',
+        'panelObjectState.ondrawend: bulk patchmap.update({ elements: items, changes: panelState.init() })',
+        'highlightPlugin: bulk attrs alpha updates for selected and non-selected items',
+      ],
+    });
+
+    isPrepared = true;
+  };
+
+  const runPanelInitUpdate = (changes) => {
+    patchmap.update({ elements: panelItems, changes });
+  };
+
+  const runPanelTrustedInitUpdate = (changes) => {
+    patchmap.update({
+      elements: panelItems,
+      changes,
+      validateSchema: false,
+      emit: false,
+    });
+  };
+
+  const runPanelPerItemUpdate = (changesList) => {
+    for (let index = 0; index < panelItems.length; index += 1) {
+      patchmap.update({
+        elements: panelItems[index],
+        changes: changesList[index],
+        validateSchema: false,
+        emit: false,
+      });
     }
-  },
-);
+  };
+
+  const runHighlightUpdate = (variant) => {
+    const highlightItems = [];
+    const notHighlightItems = [];
+    for (let index = 0; index < allItems.length; index += 1) {
+      if ((index + variant) % 7 === 0) {
+        highlightItems.push(allItems[index]);
+      } else {
+        notHighlightItems.push(allItems[index]);
+      }
+    }
+
+    patchmap.update({
+      elements: highlightItems,
+      changes: { attrs: { alpha: 1 } },
+    });
+    patchmap.update({
+      elements: notHighlightItems,
+      changes: { attrs: { alpha: 0.5 } },
+    });
+  };
+
+  const runTrustedHighlightUpdate = (variant) => {
+    const highlightItems = [];
+    const notHighlightItems = [];
+    for (let index = 0; index < allItems.length; index += 1) {
+      if ((index + variant) % 7 === 0) {
+        highlightItems.push(allItems[index]);
+      } else {
+        notHighlightItems.push(allItems[index]);
+      }
+    }
+
+    patchmap.update({
+      elements: highlightItems,
+      changes: { attrs: { alpha: 1 } },
+      validateSchema: false,
+      emit: false,
+    });
+    patchmap.update({
+      elements: notHighlightItems,
+      changes: { attrs: { alpha: 0.5 } },
+      validateSchema: false,
+      emit: false,
+    });
+  };
+
+  afterAll(() => {
+    if (patchmap) {
+      patchmap.destroy();
+      patchmap = undefined;
+    }
+    if (hostElement?.parentElement) {
+      hostElement.parentElement.removeChild(hostElement);
+    }
+    hostElement = undefined;
+  });
+
+  bench(
+    'dashboard panel ondrawend: bulk init update',
+    () => {
+      runPanelInitUpdate(panelInitA);
+      runPanelInitUpdate(panelInitB);
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchmap },
+  );
+
+  bench(
+    'dashboard panel ondrawend: trusted bulk init update',
+    () => {
+      runPanelTrustedInitUpdate(panelInitA);
+      runPanelTrustedInitUpdate(panelInitB);
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchmap },
+  );
+
+  bench(
+    'dashboard panel refresh: per-item chart update',
+    () => {
+      runPanelPerItemUpdate(panelChartA);
+      runPanelPerItemUpdate(panelChartB);
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchmap },
+  );
+
+  bench(
+    'dashboard panel refresh: per-item mixed state update',
+    () => {
+      runPanelPerItemUpdate(panelMixedA);
+      runPanelPerItemUpdate(panelMixedB);
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchmap },
+  );
+
+  bench(
+    'dashboard highlight: bulk alpha update',
+    () => {
+      runHighlightUpdate(0);
+      runHighlightUpdate(1);
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchmap },
+  );
+
+  bench(
+    'dashboard highlight: trusted bulk alpha update',
+    () => {
+      runTrustedHighlightUpdate(0);
+      runTrustedHighlightUpdate(1);
+    },
+    { ...BENCH_OPTIONS, setup: setupPatchmap },
+  );
+});

--- a/src/tests/render/components/Icon.test.js
+++ b/src/tests/render/components/Icon.test.js
@@ -86,6 +86,19 @@ describe('Icon Component Tests', () => {
   });
 
   describe('size', () => {
+    it('should preserve raw numeric size during trusted initial draw', () => {
+      const patchmap = getPatchmap();
+      patchmap.draw([itemWithIcon]);
+
+      const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
+      expect(icon.props.size).toEqual({
+        width: { value: 50, unit: 'px' },
+        height: { value: 50, unit: 'px' },
+      });
+      expect(icon.width).toBe(50);
+      expect(icon.height).toBe(50);
+    });
+
     it('should correctly resize the icon when a single number is provided for size', () => {
       const patchmap = getPatchmap();
       patchmap.draw([itemWithIcon]);
@@ -174,22 +187,22 @@ describe('Icon Component Tests', () => {
       { placement: 'right-top', expected: { x: 50, y: 0 } },
       { placement: 'left-bottom', expected: { x: 0, y: 50 } },
       { placement: 'right-bottom', expected: { x: 50, y: 50 } },
-    ])(
-      'should correctly position the icon for placement: $placement',
-      ({ placement, expected }) => {
-        const patchmap = getPatchmap();
-        patchmap.draw([itemWithIcon]);
+    ])('should correctly position the icon for placement: $placement', ({
+      placement,
+      expected,
+    }) => {
+      const patchmap = getPatchmap();
+      patchmap.draw([itemWithIcon]);
 
-        patchmap.update({
-          path: '$..[?(@.id=="icon-1")]',
-          changes: { placement: placement },
-        });
+      patchmap.update({
+        path: '$..[?(@.id=="icon-1")]',
+        changes: { placement: placement },
+      });
 
-        const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
-        expect(icon.x).toBe(expected.x);
-        expect(icon.y).toBe(expected.y);
-      },
-    );
+      const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
+      expect(icon.x).toBe(expected.x);
+      expect(icon.y).toBe(expected.y);
+    });
   });
 
   describe('margin', () => {
@@ -230,22 +243,23 @@ describe('Icon Component Tests', () => {
         placement: 'right-top',
         expected: { x: 45, y: -10 },
       },
-    ])(
-      'should correctly apply margin with placement: $case',
-      ({ margin, placement, expected }) => {
-        const patchmap = getPatchmap();
-        patchmap.draw([itemWithIcon]);
+    ])('should correctly apply margin with placement: $case', ({
+      margin,
+      placement,
+      expected,
+    }) => {
+      const patchmap = getPatchmap();
+      patchmap.draw([itemWithIcon]);
 
-        patchmap.update({
-          path: '$..[?(@.id=="icon-1")]',
-          changes: { placement, margin },
-        });
+      patchmap.update({
+        path: '$..[?(@.id=="icon-1")]',
+        changes: { placement, margin },
+      });
 
-        const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
-        expect(icon.x).toBe(expected.x);
-        expect(icon.y).toBe(expected.y);
-      },
-    );
+      const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
+      expect(icon.x).toBe(expected.x);
+      expect(icon.y).toBe(expected.y);
+    });
   });
 
   describe('size, placement, margin', () => {
@@ -288,24 +302,24 @@ describe('Icon Component Tests', () => {
         changes: { size: '30%', placement: 'bottom', margin: { y: -5 } },
         expected: { x: 35, y: 75, width: 30, height: 30 },
       },
-    ])(
-      'should correctly calculate position and size with combined properties for: $case',
-      ({ changes, expected }) => {
-        const patchmap = getPatchmap();
-        patchmap.draw([itemWithIcon]);
+    ])('should correctly calculate position and size with combined properties for: $case', ({
+      changes,
+      expected,
+    }) => {
+      const patchmap = getPatchmap();
+      patchmap.draw([itemWithIcon]);
 
-        patchmap.update({
-          path: '$..[?(@.id=="icon-1")]',
-          changes: changes,
-        });
+      patchmap.update({
+        path: '$..[?(@.id=="icon-1")]',
+        changes: changes,
+      });
 
-        const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
-        expect(icon.width).toBeCloseTo(expected.width);
-        expect(icon.height).toBeCloseTo(expected.height);
-        expect(icon.x).toBeCloseTo(expected.x);
-        expect(icon.y).toBeCloseTo(expected.y);
-      },
-    );
+      const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
+      expect(icon.width).toBeCloseTo(expected.width);
+      expect(icon.height).toBeCloseTo(expected.height);
+      expect(icon.x).toBeCloseTo(expected.x);
+      expect(icon.y).toBeCloseTo(expected.y);
+    });
   });
 
   describe('tint', () => {

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -207,6 +207,44 @@ describe('patchmap test', () => {
     expect(patchmap.selector('$..[?(@.id=="group-1")]')[0].x).toBe(321);
   });
 
+  it('applies component schema defaults when update adds item components', async () => {
+    const patchmap = getPatchmap();
+    patchmap.draw([
+      {
+        type: 'item',
+        id: 'dashboard-item',
+        size: { width: 120, height: 80 },
+        components: [],
+      },
+    ]);
+
+    patchmap.update({
+      path: '$..[?(@.id=="dashboard-item")]',
+      changes: {
+        components: [
+          { type: 'text', id: 'dashboard-text', text: 'OK' },
+          { type: 'icon', id: 'dashboard-icon', source: 'device', size: 16 },
+        ],
+      },
+    });
+    await waitForScene();
+
+    const text = patchmap.selector('$..[?(@.id=="dashboard-text")]')[0];
+    const icon = patchmap.selector('$..[?(@.id=="dashboard-icon")]')[0];
+    expect(text.props.placement).toBe('center');
+    expect(text.props.margin).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+    expect(icon.props.placement).toBe('center');
+    expect(icon.props.size).toEqual({
+      width: { value: 16, unit: 'px' },
+      height: { value: 16, unit: 'px' },
+    });
+  });
+
   it('sorts top-level world children by zIndex after draw and update', async () => {
     const patchmap = getPatchmap();
     patchmap.draw([


### PR DESCRIPTION
## Summary
- propagate schema-skip behavior and add initial creation fast paths for draw
- preserve component defaults/raw size behavior when validateSchema is disabled
- add draw/update performance benches with synthetic plant-map data

## Verification
- npx vitest --project unit run src/display/mixins src/display/data-schema/component-schema.test.js src/display/data-schema/element-schema.test.js
- npx vitest --project browser run src/tests/render/components/Icon.test.js
- rm -rf dist && npm run build