### PR TITLE
fix: apply schema defaults without schema validation

### DIFF
--- a/src/display/default-props.js
+++ b/src/display/default-props.js
@@ -15,6 +15,8 @@ const DEFAULT_COMPONENT_SIZE = Object.freeze({
   height: { value: 100, unit: '%' },
 });
 
+const defaultComponentSize = () => structuredClone(DEFAULT_COMPONENT_SIZE);
+
 const withBaseDefaults = (value) => {
   if (!isPlainObject(value)) return value;
 
@@ -119,6 +121,9 @@ export const applyElementDefaults = (value) => {
       if (next.inactiveCellStrategy === undefined) {
         next = { ...next, inactiveCellStrategy: 'destroy' };
       }
+      if (next.gap === undefined) {
+        next = { ...next, gap: { x: 0, y: 0 } };
+      }
       if (isPlainObject(next.item)) {
         next = { ...next, item: withGridItemDefaults(next.item) };
       }
@@ -163,9 +168,7 @@ export const applyComponentDefaults = (value) => {
 
   switch (next.type) {
     case 'background':
-      if (next.size !== undefined) {
-        next = { ...next, size: structuredClone(DEFAULT_COMPONENT_SIZE) };
-      }
+      next = { ...next, size: defaultComponentSize() };
       break;
     case 'bar':
       if (next.placement === undefined) {

--- a/src/display/default-props.js
+++ b/src/display/default-props.js
@@ -1,0 +1,212 @@
+import { isPlainObject } from 'is-plain-object';
+import { normalizeBoxSpacing } from '../utils/spacing';
+import { uid } from '../utils/uuid';
+import {
+  DEFAULT_AUTO_FONT_RANGE,
+  DEFAULT_PATHSTYLE,
+  DEFAULT_TEXTSTYLE,
+} from './mixins/constants';
+import { normalizeChanges } from './normalize';
+
+const COMPONENT_TYPES = new Set(['background', 'bar', 'icon', 'text']);
+
+const DEFAULT_COMPONENT_SIZE = Object.freeze({
+  width: { value: 100, unit: '%' },
+  height: { value: 100, unit: '%' },
+});
+
+const withBaseDefaults = (value) => {
+  if (!isPlainObject(value)) return value;
+
+  let next = value;
+  if (next.show === undefined) {
+    next = { ...next, show: true };
+  }
+  if (next.id === undefined) {
+    next = { ...next, id: uid() };
+  }
+  return next;
+};
+
+const withElementBaseDefaults = (value) => {
+  let next = withBaseDefaults(value);
+  if (!isPlainObject(next)) return next;
+
+  if (next.locked === undefined) {
+    next = { ...next, locked: false };
+  }
+  return next;
+};
+
+const withTextStyleDefaults = (style) => ({
+  fontFamily: DEFAULT_TEXTSTYLE.fontFamily,
+  fontWeight: DEFAULT_TEXTSTYLE.fontWeight,
+  fill: DEFAULT_TEXTSTYLE.fill,
+  fontSize: 16,
+  ...style,
+});
+
+const withLabelTextStyleDefaults = (style) => {
+  const current = isPlainObject(style) ? style : {};
+  const autoFont = isPlainObject(current.autoFont) ? current.autoFont : {};
+
+  return {
+    ...withTextStyleDefaults(current),
+    autoFont: {
+      min: DEFAULT_AUTO_FONT_RANGE.min,
+      max: DEFAULT_AUTO_FONT_RANGE.max,
+      ...autoFont,
+    },
+    overflow: current.overflow ?? 'visible',
+  };
+};
+
+const withElementTextStyleDefaults = (style) => {
+  const current = isPlainObject(style) ? style : {};
+
+  return {
+    ...withTextStyleDefaults(current),
+    wordWrap: current.wordWrap ?? true,
+    letterSpacing: current.letterSpacing ?? 0,
+  };
+};
+
+const withStrokeStyleDefaults = (style) => ({
+  color: DEFAULT_PATHSTYLE.color,
+  ...(isPlainObject(style) ? style : {}),
+});
+
+const withItemLikeDefaults = (value) => {
+  let next = value;
+  if (next.components === undefined) {
+    next = { ...next, components: [] };
+  }
+  if (next.padding === undefined) {
+    next = { ...next, padding: normalizeBoxSpacing(0) };
+  }
+  if (next.contentOrientation === undefined) {
+    next = { ...next, contentOrientation: 'upright' };
+  }
+  if (Array.isArray(next.components)) {
+    next = {
+      ...next,
+      components: next.components.map(applyComponentDefaults),
+    };
+  }
+  return next;
+};
+
+const withGridItemDefaults = (item) => {
+  if (!isPlainObject(item)) return item;
+  return normalizeChanges(withItemLikeDefaults(item), 'item');
+};
+
+export const applyElementDefaults = (value) => {
+  if (!isPlainObject(value)) return value;
+
+  let next = withElementBaseDefaults(value);
+
+  switch (next.type) {
+    case 'group':
+      if (Array.isArray(next.children)) {
+        next = {
+          ...next,
+          children: next.children.map(applyElementDefaults),
+        };
+      }
+      break;
+    case 'grid':
+      if (next.inactiveCellStrategy === undefined) {
+        next = { ...next, inactiveCellStrategy: 'destroy' };
+      }
+      if (isPlainObject(next.item)) {
+        next = { ...next, item: withGridItemDefaults(next.item) };
+      }
+      break;
+    case 'item':
+      next = withItemLikeDefaults(next);
+      break;
+    case 'relations':
+      if (next.style === undefined) {
+        next = { ...next, style: withStrokeStyleDefaults() };
+      } else if (isPlainObject(next.style)) {
+        next = { ...next, style: withStrokeStyleDefaults(next.style) };
+      }
+      break;
+    case 'text':
+      if (next.text === undefined) {
+        next = { ...next, text: '' };
+      }
+      if (next.style === undefined || isPlainObject(next.style)) {
+        next = { ...next, style: withElementTextStyleDefaults(next.style) };
+      }
+      break;
+    case 'rect':
+      if (next.radius === undefined) {
+        next = { ...next, radius: 0 };
+      }
+      break;
+  }
+
+  return normalizeChanges(next, next.type);
+};
+
+export const applyComponentDefaults = (value) => {
+  if (!isPlainObject(value)) return value;
+  if (!COMPONENT_TYPES.has(value.type)) return value;
+
+  let next = withBaseDefaults(value);
+
+  if (next.tint === undefined) {
+    next = { ...next, tint: 0xffffff };
+  }
+
+  switch (next.type) {
+    case 'background':
+      if (next.size !== undefined) {
+        next = { ...next, size: structuredClone(DEFAULT_COMPONENT_SIZE) };
+      }
+      break;
+    case 'bar':
+      if (next.placement === undefined) {
+        next = { ...next, placement: 'bottom' };
+      }
+      if (next.margin === undefined) {
+        next = { ...next, margin: normalizeBoxSpacing(0) };
+      }
+      if (next.animation === undefined) {
+        next = { ...next, animation: true };
+      }
+      if (next.animationDuration === undefined) {
+        next = { ...next, animationDuration: 200 };
+      }
+      break;
+    case 'icon':
+      if (next.placement === undefined) {
+        next = { ...next, placement: 'center' };
+      }
+      if (next.margin === undefined) {
+        next = { ...next, margin: normalizeBoxSpacing(0) };
+      }
+      break;
+    case 'text':
+      if (next.placement === undefined) {
+        next = { ...next, placement: 'center' };
+      }
+      if (next.margin === undefined) {
+        next = { ...next, margin: normalizeBoxSpacing(0) };
+      }
+      if (next.text === undefined) {
+        next = { ...next, text: '' };
+      }
+      if (next.style === undefined || isPlainObject(next.style)) {
+        next = { ...next, style: withLabelTextStyleDefaults(next.style) };
+      }
+      if (next.split === undefined) {
+        next = { ...next, split: 0 };
+      }
+      break;
+  }
+
+  return normalizeChanges(next, next.type);
+};

--- a/src/display/default-props.js
+++ b/src/display/default-props.js
@@ -10,32 +10,44 @@ import { normalizeChanges } from './normalize';
 
 const COMPONENT_TYPES = new Set(['background', 'bar', 'icon', 'text']);
 
-const DEFAULT_COMPONENT_SIZE = Object.freeze({
+const defaultComponentSize = () => ({
   width: { value: 100, unit: '%' },
   height: { value: 100, unit: '%' },
 });
 
-const defaultComponentSize = () => structuredClone(DEFAULT_COMPONENT_SIZE);
-
 const withBaseDefaults = (value) => {
   if (!isPlainObject(value)) return value;
+  if (value.show !== undefined && value.id !== undefined) return value;
 
-  let next = value;
+  const next = { ...value };
   if (next.show === undefined) {
-    next = { ...next, show: true };
+    next.show = true;
   }
   if (next.id === undefined) {
-    next = { ...next, id: uid() };
+    next.id = uid();
   }
   return next;
 };
 
 const withElementBaseDefaults = (value) => {
-  let next = withBaseDefaults(value);
-  if (!isPlainObject(next)) return next;
+  if (!isPlainObject(value)) return value;
+  if (
+    value.show !== undefined &&
+    value.id !== undefined &&
+    value.locked !== undefined
+  ) {
+    return value;
+  }
 
+  const next = { ...value };
+  if (next.show === undefined) {
+    next.show = true;
+  }
+  if (next.id === undefined) {
+    next.id = uid();
+  }
   if (next.locked === undefined) {
-    next = { ...next, locked: false };
+    next.locked = false;
   }
   return next;
 };
@@ -78,7 +90,8 @@ const withStrokeStyleDefaults = (style) => ({
   ...(isPlainObject(style) ? style : {}),
 });
 
-const withItemLikeDefaults = (value) => {
+const withItemLikeDefaults = (value, options = {}) => {
+  const { materializeComponents = true } = options;
   let next = value;
   if (next.components === undefined) {
     next = { ...next, components: [] };
@@ -89,7 +102,7 @@ const withItemLikeDefaults = (value) => {
   if (next.contentOrientation === undefined) {
     next = { ...next, contentOrientation: 'upright' };
   }
-  if (Array.isArray(next.components)) {
+  if (materializeComponents && Array.isArray(next.components)) {
     next = {
       ...next,
       components: next.components.map(applyComponentDefaults),
@@ -100,7 +113,10 @@ const withItemLikeDefaults = (value) => {
 
 const withGridItemDefaults = (item) => {
   if (!isPlainObject(item)) return item;
-  return normalizeChanges(withItemLikeDefaults(item), 'item');
+  return normalizeChanges(
+    withItemLikeDefaults(item, { materializeComponents: false }),
+    'item',
+  );
 };
 
 export const applyElementDefaults = (value) => {

--- a/src/display/mixins/Cellsable.js
+++ b/src/display/mixins/Cellsable.js
@@ -38,7 +38,7 @@ export const Cellsable = (superClass) => {
             const itemChanges = {
               type: 'item',
               id,
-              ...itemProps,
+              ...cloneGridItemTemplate(itemProps),
               label,
               attrs,
               show: !isInactive,
@@ -80,6 +80,20 @@ const canUseInitialFastPath = (options) =>
   options.mergeStrategy === 'replace' &&
   options.validateSchema === false &&
   options.normalize === false;
+
+const cloneGridItemTemplate = (itemProps) => {
+  if (!Array.isArray(itemProps?.components)) return itemProps;
+  return {
+    ...itemProps,
+    components: itemProps.components.map((component) =>
+      component && typeof component === 'object'
+        ? omitComponentTemplateId(component)
+        : component,
+    ),
+  };
+};
+
+const omitComponentTemplateId = ({ id, ...component }) => component;
 
 const applyInitialCellItem = (item, itemChanges, options) => {
   const applyOptions = {

--- a/src/display/mixins/Cellsable.js
+++ b/src/display/mixins/Cellsable.js
@@ -1,3 +1,4 @@
+import { applyElementDefaults } from '../default-props';
 import { newElement } from '../elements/creator';
 import { UPDATE_STAGES } from './constants';
 
@@ -42,7 +43,11 @@ export const Cellsable = (superClass) => {
               attrs,
               show: !isInactive,
             };
-            applyInitialCellItem(item, itemChanges, options);
+            applyInitialCellItem(
+              item,
+              applyElementDefaults(itemChanges),
+              options,
+            );
           } else {
             const itemChanges = { label, show: !isInactive };
             existingItem.apply(itemChanges, {

--- a/src/display/mixins/Childrenable.js
+++ b/src/display/mixins/Childrenable.js
@@ -1,6 +1,7 @@
 import { deepMerge } from '../../utils/deepmerge/deepmerge';
 import { findIndexByPriority } from '../../utils/findIndexByPriority';
 import { mapDataSchema } from '../data-schema/element-schema';
+import { applyElementDefaults } from '../default-props';
 import { newElement } from '../elements/creator';
 import { UPDATE_STAGES } from './constants';
 import { validateAndPrepareChanges } from './utils';
@@ -24,7 +25,7 @@ export const Childrenable = (superClass) => {
         elements,
         childrenChanges,
         mapDataSchema,
-        childOptions,
+        { ...childOptions, defaultMaterializer: applyElementDefaults },
       );
 
       for (const childChange of childrenChanges) {

--- a/src/display/mixins/Componentsable.js
+++ b/src/display/mixins/Componentsable.js
@@ -2,6 +2,7 @@ import { deepMerge } from '../../utils/deepmerge/deepmerge';
 import { findIndexByPriority } from '../../utils/findIndexByPriority';
 import { newComponent } from '../components/creator';
 import { componentArraySchema } from '../data-schema/component-schema';
+import { applyComponentDefaults } from '../default-props';
 import { UPDATE_STAGES } from './constants';
 import { validateAndPrepareChanges } from './utils';
 
@@ -25,7 +26,7 @@ export const Componentsable = (superClass) => {
         components,
         componentsChanges,
         componentArraySchema,
-        childOptions,
+        { ...childOptions, defaultMaterializer: applyComponentDefaults },
       );
 
       for (const componentChange of componentsChanges) {

--- a/src/display/mixins/Itemable.js
+++ b/src/display/mixins/Itemable.js
@@ -13,7 +13,8 @@ export const Itemable = (superClass) => {
         return;
       }
 
-      const { item: itemProps, gap } = relevantChanges;
+      const { gap } = relevantChanges;
+      const itemProps = resolveGridItemProps(relevantChanges, options);
 
       const gridIdPrefix = `${this.id}.`;
       for (const child of this.children) {
@@ -42,4 +43,16 @@ export const Itemable = (superClass) => {
     UPDATE_STAGES.VISUAL,
   );
   return MixedClass;
+};
+
+const resolveGridItemProps = (relevantChanges, options = {}) => {
+  const rawItemChanges = options.changes?.item;
+  if (!rawItemChanges || typeof rawItemChanges !== 'object') {
+    return relevantChanges.item;
+  }
+
+  return {
+    ...relevantChanges.item,
+    ...rawItemChanges,
+  };
 };

--- a/src/display/mixins/linksable.js
+++ b/src/display/mixins/linksable.js
@@ -26,27 +26,27 @@ export const Linksable = (superClass) => {
     }
 
     _onObjectTransformed(changedObject) {
-      if (!this.linkedObjects) return;
+      if (!this.linkedObjects || !changedObject || changedObject.destroyed)
+        return;
       if (changedObject === this.store?.world) return;
 
-      const values = Object.values(this.linkedObjects);
-      for (const linkedObj of values) {
-        if (!linkedObj || linkedObj.destroyed) continue;
-
-        if (
-          linkedObj === changedObject ||
-          isAncestor(changedObject, linkedObj) ||
-          isAncestor(linkedObj, changedObject)
-        ) {
-          this._renderDirty = true;
-          return;
-        }
+      if (
+        this.linkedObjectSet?.has(changedObject) ||
+        this.linkedAncestorSet?.has(changedObject) ||
+        hasAncestorInSet(changedObject, this.linkedObjectSet)
+      ) {
+        this._renderDirty = true;
       }
     }
 
     _applyLinks(relevantChanges) {
       const { links } = relevantChanges;
       this.linkedObjects = uniqueLinked(this.store, links);
+      const { linkedObjectSet, linkedAncestorSet } = buildLinkedObjectLookup(
+        this.linkedObjects,
+      );
+      this.linkedObjectSet = linkedObjectSet;
+      this.linkedAncestorSet = linkedAncestorSet;
       this._renderDirty = true;
     }
   };
@@ -58,12 +58,12 @@ export const Linksable = (superClass) => {
   return MixedClass;
 };
 
-const isAncestor = (parent, target) => {
-  if (!target || !parent) return false;
+const hasAncestorInSet = (target, objectSet) => {
+  if (!target || !objectSet) return false;
 
   let current = target.parent;
   while (current) {
-    if (current === parent) {
+    if (objectSet.has(current)) {
       return true;
     }
     if (current.type === 'canvas' || !current.parent) {
@@ -72,6 +72,25 @@ const isAncestor = (parent, target) => {
     current = current.parent;
   }
   return false;
+};
+
+const buildLinkedObjectLookup = (linkedObjects) => {
+  const linkedObjectSet = new Set();
+  const linkedAncestorSet = new Set();
+
+  for (const linkedObj of Object.values(linkedObjects ?? {})) {
+    if (!linkedObj || linkedObj.destroyed) continue;
+
+    linkedObjectSet.add(linkedObj);
+    let current = linkedObj.parent;
+    while (current) {
+      linkedAncestorSet.add(current);
+      if (current.type === 'canvas' || !current.parent) break;
+      current = current.parent;
+    }
+  }
+
+  return { linkedObjectSet, linkedAncestorSet };
 };
 
 const uniqueLinked = (store, links) => {

--- a/src/display/mixins/utils.js
+++ b/src/display/mixins/utils.js
@@ -188,7 +188,7 @@ export const mixins = (baseClass, ...mixins) => {
  * @param {Array<object>} currentElements - Array of current child elements (components) in the DOM
  * @param {Array<object>} changes - Array of change data to apply
  * @param {import('zod').ZodSchema} schema - Zod schema to use for validation
- * @param {{ validateSchema?: boolean }} options - Validation controls
+ * @param {{ validateSchema?: boolean, defaultMaterializer?: (value: object) => object }} options - Validation controls
  * @returns {Array<object>} The changes array, with validated and default-filled data
  */
 export const validateAndPrepareChanges = (
@@ -213,6 +213,13 @@ export const validateAndPrepareChanges = (
   });
 
   if (options.validateSchema === false) {
+    if (typeof options.defaultMaterializer === 'function') {
+      newElementIndices.forEach((originalIndex) => {
+        preparedChanges[originalIndex] = options.defaultMaterializer(
+          preparedChanges[originalIndex],
+        );
+      });
+    }
     return preparedChanges;
   }
 

--- a/src/display/mixins/utils.test.js
+++ b/src/display/mixins/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { applyComponentDefaults } from '../default-props';
+import { applyComponentDefaults, applyElementDefaults } from '../default-props';
 import {
   calcSize,
   parseCalcExpression,
@@ -266,5 +266,39 @@ describe('validateAndPrepareChanges', () => {
         split: 0,
       },
     ]);
+  });
+
+  it('applies draw fast path defaults that schema validation would normally provide', () => {
+    expect(
+      applyElementDefaults({
+        type: 'grid',
+        id: 'grid',
+        cells: [[1]],
+        item: { size: 40 },
+      }),
+    ).toMatchObject({
+      type: 'grid',
+      gap: { x: 0, y: 0 },
+      inactiveCellStrategy: 'destroy',
+      item: {
+        size: { width: 40, height: 40 },
+        components: [],
+        padding: { top: 0, right: 0, bottom: 0, left: 0 },
+        contentOrientation: 'upright',
+      },
+    });
+
+    expect(
+      applyComponentDefaults({
+        type: 'background',
+        source: { type: 'rect' },
+      }),
+    ).toMatchObject({
+      type: 'background',
+      size: {
+        width: { value: 100, unit: '%' },
+        height: { value: 100, unit: '%' },
+      },
+    });
   });
 });

--- a/src/display/mixins/utils.test.js
+++ b/src/display/mixins/utils.test.js
@@ -301,4 +301,33 @@ describe('validateAndPrepareChanges', () => {
       },
     });
   });
+
+  it('does not assign component ids to grid item templates', () => {
+    const grid = applyElementDefaults({
+      type: 'grid',
+      id: 'grid',
+      cells: [[1]],
+      gap: 0,
+      item: {
+        size: 40,
+        components: [{ type: 'text' }],
+      },
+    });
+
+    expect(grid.item.components).toEqual([{ type: 'text' }]);
+
+    const template = { size: 40, components: [{ type: 'text' }] };
+    const firstCell = applyElementDefaults({
+      type: 'item',
+      id: 'grid.0.0',
+      ...template,
+    });
+    const secondCell = applyElementDefaults({
+      type: 'item',
+      id: 'grid.0.1',
+      ...template,
+    });
+
+    expect(firstCell.components[0].id).not.toBe(secondCell.components[0].id);
+  });
 });

--- a/src/display/mixins/utils.test.js
+++ b/src/display/mixins/utils.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import { applyComponentDefaults } from '../default-props';
 import {
   calcSize,
   parseCalcExpression,
@@ -228,6 +229,42 @@ describe('validateAndPrepareChanges', () => {
     ).toEqual([{ type: 'icon' }]);
     expect(validateAndPrepareChanges([], changes, schema)).toEqual([
       { type: 'icon', source: 'wifi' },
+    ]);
+  });
+
+  it('applies lightweight defaults without schema validation when validateSchema is false', () => {
+    const changes = [{ type: 'text' }];
+    const schema = z.array(
+      z.object({
+        type: z.string(),
+        source: z.string(),
+      }),
+    );
+
+    expect(
+      validateAndPrepareChanges([], changes, schema, {
+        validateSchema: false,
+        defaultMaterializer: applyComponentDefaults,
+      }),
+    ).toEqual([
+      {
+        type: 'text',
+        id: expect.any(String),
+        show: true,
+        tint: 0xffffff,
+        placement: 'center',
+        margin: { top: 0, right: 0, bottom: 0, left: 0 },
+        text: '',
+        style: {
+          fontFamily: 'FiraCode',
+          fontWeight: 400,
+          fill: 'black',
+          fontSize: 16,
+          autoFont: { min: 1, max: 100 },
+          overflow: 'visible',
+        },
+        split: 0,
+      },
     ]);
   });
 });

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -208,6 +208,62 @@ describe('patchmap test', () => {
     expect(patchmap.selector('$..[?(@.id=="group-1")]')[0].x).toBe(321);
   });
 
+  it('applies lightweight defaults during draw without schema validation', () => {
+    const patchmap = getPatchmap();
+    patchmap.draw([
+      {
+        type: 'grid',
+        id: 'default-grid',
+        cells: [[1]],
+        gap: 4,
+        item: {
+          size: 40,
+          components: [{ type: 'text' }],
+        },
+      },
+      {
+        type: 'item',
+        id: 'default-item',
+        size: 80,
+        components: [{ type: 'text', id: 'default-text' }],
+      },
+      {
+        type: 'relations',
+        id: 'default-relations',
+        links: [{ source: 'default-grid.0.0', target: 'default-item' }],
+      },
+    ]);
+
+    const item = patchmap.selector('$..[?(@.id=="default-item")]')[0];
+    const text = patchmap.selector('$..[?(@.id=="default-text")]')[0];
+    const grid = patchmap.selector('$..[?(@.id=="default-grid")]')[0];
+    const gridItem = patchmap.selector('$..[?(@.id=="default-grid.0.0")]')[0];
+    const relations = patchmap.selector('$..[?(@.id=="default-relations")]')[0];
+
+    expect(item.props.locked).toBe(false);
+    expect(item.props.contentOrientation).toBe('upright');
+    expect(item.props.padding).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+    expect(text.props.placement).toBe('center');
+    expect(text.props.margin).toEqual({
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+    expect(text.props.text).toBe('');
+    expect(text.props.style.overflow).toBe('visible');
+    expect(grid.props.inactiveCellStrategy).toBe('destroy');
+    expect(grid.props.gap).toEqual({ x: 4, y: 4 });
+    expect(grid.props.item.contentOrientation).toBe('upright');
+    expect(gridItem.props.contentOrientation).toBe('upright');
+    expect(relations.props.style.color).toBe('#1A1A1A');
+  });
+
   it('applies component schema defaults when update adds item components', async () => {
     const patchmap = getPatchmap();
     patchmap.draw([

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -214,7 +214,7 @@ describe('patchmap test', () => {
       {
         type: 'grid',
         id: 'default-grid',
-        cells: [[1]],
+        cells: [[1, 1]],
         item: {
           size: 40,
           components: [{ type: 'text' }],
@@ -247,6 +247,9 @@ describe('patchmap test', () => {
     )[0];
     const grid = patchmap.selector('$..[?(@.id=="default-grid")]')[0];
     const gridItem = patchmap.selector('$..[?(@.id=="default-grid.0.0")]')[0];
+    const nextGridItem = patchmap.selector(
+      '$..[?(@.id=="default-grid.0.1")]',
+    )[0];
     const relations = patchmap.selector('$..[?(@.id=="default-relations")]')[0];
 
     expect(item.props.locked).toBe(false);
@@ -273,7 +276,15 @@ describe('patchmap test', () => {
     expect(grid.props.inactiveCellStrategy).toBe('destroy');
     expect(grid.props.gap).toEqual({ x: 0, y: 0 });
     expect(grid.props.item.contentOrientation).toBe('upright');
+    expect(gridItem.id).toBe('default-grid.0.0');
+    expect(nextGridItem.id).toBe('default-grid.0.1');
+    expect(gridItem).not.toBe(nextGridItem);
     expect(gridItem.props.contentOrientation).toBe('upright');
+    expect(gridItem.props.components[0].id).toEqual(expect.any(String));
+    expect(nextGridItem.props.components[0].id).toEqual(expect.any(String));
+    expect(gridItem.props.components[0].id).not.toBe(
+      nextGridItem.props.components[0].id,
+    );
     expect(relations.props.style.color).toBe('#1A1A1A');
   });
 

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -215,7 +215,6 @@ describe('patchmap test', () => {
         type: 'grid',
         id: 'default-grid',
         cells: [[1]],
-        gap: 4,
         item: {
           size: 40,
           components: [{ type: 'text' }],
@@ -225,7 +224,14 @@ describe('patchmap test', () => {
         type: 'item',
         id: 'default-item',
         size: 80,
-        components: [{ type: 'text', id: 'default-text' }],
+        components: [
+          {
+            type: 'background',
+            id: 'default-background',
+            source: { type: 'rect' },
+          },
+          { type: 'text', id: 'default-text' },
+        ],
       },
       {
         type: 'relations',
@@ -236,6 +242,9 @@ describe('patchmap test', () => {
 
     const item = patchmap.selector('$..[?(@.id=="default-item")]')[0];
     const text = patchmap.selector('$..[?(@.id=="default-text")]')[0];
+    const background = patchmap.selector(
+      '$..[?(@.id=="default-background")]',
+    )[0];
     const grid = patchmap.selector('$..[?(@.id=="default-grid")]')[0];
     const gridItem = patchmap.selector('$..[?(@.id=="default-grid.0.0")]')[0];
     const relations = patchmap.selector('$..[?(@.id=="default-relations")]')[0];
@@ -257,8 +266,12 @@ describe('patchmap test', () => {
     });
     expect(text.props.text).toBe('');
     expect(text.props.style.overflow).toBe('visible');
+    expect(background.props.size).toEqual({
+      width: { value: 100, unit: '%' },
+      height: { value: 100, unit: '%' },
+    });
     expect(grid.props.inactiveCellStrategy).toBe('destroy');
-    expect(grid.props.gap).toEqual({ x: 4, y: 4 });
+    expect(grid.props.gap).toEqual({ x: 0, y: 0 });
     expect(grid.props.item.contentOrientation).toBe('upright');
     expect(gridItem.props.contentOrientation).toBe('upright');
     expect(relations.props.style.color).toBe('#1A1A1A');


### PR DESCRIPTION
## Summary
- add lightweight default materializers for display elements and components
- apply defaults on validateSchema:false fast paths without running schema validation
- cover draw-time defaults and validateSchema:false default materialization with tests

## Verification
- npx biome check src/display/default-props.js src/display/mixins/Childrenable.js src/display/mixins/Componentsable.js src/display/mixins/Cellsable.js src/display/mixins/utils.js src/display/mixins/utils.test.js src/tests/render/patchmap.test.js
- npm run test:unit -- --run src/display/mixins/utils.test.js
- npm run test:headless -- --run src/tests/render/patchmap.test.js
- npm run build
- npx vitest bench --browser.headless --run src/tests/perf/draw.bench.js