### PR TITLE
fix: smooth dashboard drag selection

### DIFF
--- a/src/display/elements/Group.js
+++ b/src/display/elements/Group.js
@@ -7,7 +7,7 @@ const ComposedGroup = mixins(Element, Childrenable);
 
 export class Group extends ComposedGroup {
   constructor(store) {
-    super({ type: 'group', store, isRenderGroup: true });
+    super({ type: 'group', store });
   }
 
   apply(changes, options) {

--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -1,4 +1,3 @@
-import { Matrix } from 'pixi.js';
 import { isValidationError } from 'zod-validation-error';
 import { UpdateCommand } from '../../command/commands/update';
 import { deepMerge } from '../../utils/deepmerge/deepmerge';
@@ -8,8 +7,18 @@ import { validate } from '../../utils/validator';
 import { normalizeChanges } from '../normalize';
 import { Type } from './Type';
 
-const tempMatrix = new Matrix();
 const RAW_SYNC_KEYS = ['id', 'label', 'attrs'];
+const TRANSFORM_SYNC_KEYS = new Set([
+  'x',
+  'y',
+  'width',
+  'height',
+  'angle',
+  'rotation',
+  'scale',
+  'skew',
+  'pivot',
+]);
 
 const getPatchDiff = (currentProps, changes) => {
   if (
@@ -46,10 +55,8 @@ export const Base = (superClass) => {
       super(rest);
       this.#store = store;
       this.props = rest?.type ? { type: rest.type } : {};
-
-      this._lastLocalTransform = tempMatrix.clone();
       this.onRender = () => {
-        this._onObjectUpdate();
+        if (this.#store?.viewport?.moving) return;
         this._afterRender();
       };
     }
@@ -60,19 +67,13 @@ export const Base = (superClass) => {
 
     _afterRender() {}
 
-    _onObjectUpdate() {
-      if (
-        this.parent?.type === 'item' ||
-        !this.localTransform ||
-        !this.visible
-      ) {
+    _emitObjectTransformed() {
+      if (this.parent?.type === 'item' || !this.visible) {
         return;
       }
 
-      if (!this.localTransform.equals(this._lastLocalTransform)) {
-        this.store.viewport?.emit('object_transformed', this);
-        this._lastLocalTransform.copyFrom(this.localTransform);
-      }
+      this.updateLocalTransform?.();
+      this.store.viewport?.emit('object_transformed', this);
     }
 
     destroy(options) {
@@ -269,23 +270,31 @@ export const Base = (superClass) => {
     }
 
     _applyRaw(attrs, mergeStrategy) {
+      let transformChanged = false;
       for (const [key, value] of Object.entries(attrs)) {
         if (value === undefined) {
           if (!['id', 'label'].includes(key)) {
             delete this[key];
+            transformChanged ||= TRANSFORM_SYNC_KEYS.has(key);
           }
         } else if (key === 'x' || key === 'y') {
           const x = key === 'x' ? value : (attrs?.x ?? this.x);
           const y = key === 'y' ? value : (attrs?.y ?? this.y);
           this.position.set(x, y);
+          transformChanged = true;
         } else if (key === 'width' || key === 'height') {
           const width = key === 'width' ? value : (attrs?.width ?? this.width);
           const height =
             key === 'height' ? value : (attrs?.height ?? this.height);
           this.setSize(width, height);
+          transformChanged = true;
         } else {
           this._updateProperty(key, value, mergeStrategy);
+          transformChanged ||= TRANSFORM_SYNC_KEYS.has(key);
         }
+      }
+      if (transformChanged) {
+        this._emitObjectTransformed();
       }
     }
 

--- a/src/display/mixins/Base.js
+++ b/src/display/mixins/Base.js
@@ -56,7 +56,12 @@ export const Base = (superClass) => {
       this.#store = store;
       this.props = rest?.type ? { type: rest.type } : {};
       this.onRender = () => {
-        if (this.#store?.viewport?.moving) return;
+        if (
+          this.#store?.viewport?.moving ||
+          this.#store?.viewport?._suspendObjectAfterRender
+        ) {
+          return;
+        }
         this._afterRender();
       };
     }

--- a/src/display/mixins/Base.test.js
+++ b/src/display/mixins/Base.test.js
@@ -12,6 +12,47 @@ class TestBase {
 class StaticBaseElement extends Base(TestBase) {}
 
 describe('Base mixin', () => {
+  it('emits object_transformed immediately when raw transform attrs change', () => {
+    const emit = vi.fn();
+    const updateLocalTransform = vi.fn();
+    const instance = new StaticBaseElement({
+      type: 'rect',
+      store: { viewport: { emit } },
+      position: { set: vi.fn() },
+      updateLocalTransform,
+      visible: true,
+    });
+
+    instance.apply(
+      { type: 'rect', attrs: { x: 12, y: 24 } },
+      z.object({
+        type: z.literal('rect'),
+        attrs: z.object({ x: z.number(), y: z.number() }),
+      }),
+    );
+
+    expect(instance.position.set).toHaveBeenCalledWith(12, 24);
+    expect(updateLocalTransform).toHaveBeenCalledOnce();
+    expect(emit).toHaveBeenCalledWith('object_transformed', instance);
+  });
+
+  it('skips after-render work while the viewport is moving', () => {
+    const instance = new StaticBaseElement({
+      type: 'rect',
+      store: { viewport: { moving: true } },
+    });
+    instance._afterRender = vi.fn();
+
+    instance.onRender();
+
+    expect(instance._afterRender).not.toHaveBeenCalled();
+
+    instance.store.viewport.moving = false;
+    instance.onRender();
+
+    expect(instance._afterRender).toHaveBeenCalledOnce();
+  });
+
   it('propagates normalized child changes back to the parent store', () => {
     const onChildUpdate = vi.fn();
     const instance = new StaticBaseElement({

--- a/src/display/mixins/Base.test.js
+++ b/src/display/mixins/Base.test.js
@@ -53,6 +53,23 @@ describe('Base mixin', () => {
     expect(instance._afterRender).toHaveBeenCalledOnce();
   });
 
+  it('skips after-render work while object after-render is suspended', () => {
+    const instance = new StaticBaseElement({
+      type: 'rect',
+      store: { viewport: { _suspendObjectAfterRender: true } },
+    });
+    instance._afterRender = vi.fn();
+
+    instance.onRender();
+
+    expect(instance._afterRender).not.toHaveBeenCalled();
+
+    instance.store.viewport._suspendObjectAfterRender = false;
+    instance.onRender();
+
+    expect(instance._afterRender).toHaveBeenCalledOnce();
+  });
+
   it('propagates normalized child changes back to the parent store', () => {
     const onChildUpdate = vi.fn();
     const instance = new StaticBaseElement({

--- a/src/display/mixins/WorldTransformable.js
+++ b/src/display/mixins/WorldTransformable.js
@@ -7,6 +7,7 @@ import {
 
 const VIEWPORT_WORLD_LISTENER = new WeakMap();
 const SNAPSHOT_PRECISION = 10000;
+const BOUNDS_SETTLE_FRAMES = 2;
 
 const normalizeSnapshotValue = (value) => {
   const parsed = Number(value);
@@ -129,6 +130,9 @@ const hasRawTransformOverride = (changes) => {
   );
 };
 
+const isViewportDragging = (instance) =>
+  Boolean(instance.store?.viewport?.moving);
+
 export const WorldTransformable = (superClass) => {
   const MixedClass = class extends superClass {
     constructor(...args) {
@@ -136,8 +140,15 @@ export const WorldTransformable = (superClass) => {
       this._worldTransformViewport = null;
       this._worldTransformEntry = null;
       this._worldTransformBoundsSnapshot = null;
+      this._worldTransformNeedsSubscriptionSync = true;
+      this._worldTransformBoundsCheckFrames = BOUNDS_SETTLE_FRAMES;
+      this._boundMarkWorldTransformTreeDirty =
+        this._markWorldTransformTreeDirty.bind(this);
+      this.on?.('added', this._boundMarkWorldTransformTreeDirty);
+      this.on?.('removed', this._boundMarkWorldTransformTreeDirty);
       this._registerWorldTransformSubscriber();
       this._applyWorldTransform();
+      this._markWorldTransformBoundsDirty();
     }
 
     _applyWorldTransform(_relevantChanges, options) {
@@ -149,6 +160,7 @@ export const WorldTransformable = (superClass) => {
 
       applyWorldRotation(this, this.store.view);
       applyWorldFlip(this, this.store.view);
+      this._markWorldTransformBoundsDirty();
     }
 
     _onWorldTransformChanged() {
@@ -159,6 +171,32 @@ export const WorldTransformable = (superClass) => {
           margin: this.props?.margin,
         });
       }
+      this._markWorldTransformBoundsDirty();
+    }
+
+    _markWorldTransformTreeDirty() {
+      this._worldTransformNeedsSubscriptionSync = true;
+      this._markWorldTransformBoundsDirty();
+    }
+
+    _markWorldTransformBoundsDirty() {
+      this._worldTransformBoundsCheckFrames = Math.max(
+        this._worldTransformBoundsCheckFrames ?? 0,
+        BOUNDS_SETTLE_FRAMES,
+      );
+    }
+
+    _onTextureApplied(texture) {
+      super._onTextureApplied?.(texture);
+      this._markWorldTransformBoundsDirty();
+    }
+
+    _applyHandlers(keysToProcess, options) {
+      const result = super._applyHandlers?.(keysToProcess, options);
+      if (keysToProcess?.length > 0) {
+        this._markWorldTransformBoundsDirty();
+      }
+      return result;
     }
 
     _registerWorldTransformSubscriber() {
@@ -193,17 +231,45 @@ export const WorldTransformable = (superClass) => {
       }
 
       if (!this._worldTransformEntry) return;
-      const changed = syncNodeSubscriptions(this._worldTransformEntry, this);
-      const nextBoundsSnapshot = getBoundsSnapshot(this);
-      const boundsChanged =
-        nextBoundsSnapshot !== this._worldTransformBoundsSnapshot;
-      this._worldTransformBoundsSnapshot = nextBoundsSnapshot;
+      if (
+        !this._worldTransformNeedsSubscriptionSync &&
+        this._worldTransformBoundsCheckFrames <= 0
+      ) {
+        return;
+      }
+      if (
+        isViewportDragging(this) &&
+        this._worldTransformBoundsSnapshot !== null &&
+        !this._worldTransformNeedsSubscriptionSync
+      ) {
+        return;
+      }
+
+      const changed = this._worldTransformNeedsSubscriptionSync
+        ? syncNodeSubscriptions(this._worldTransformEntry, this)
+        : false;
+      this._worldTransformNeedsSubscriptionSync = false;
+
+      let boundsChanged = false;
+      if (this._worldTransformBoundsCheckFrames > 0 || changed) {
+        const nextBoundsSnapshot = getBoundsSnapshot(this);
+        boundsChanged =
+          nextBoundsSnapshot !== this._worldTransformBoundsSnapshot;
+        this._worldTransformBoundsSnapshot = nextBoundsSnapshot;
+        this._worldTransformBoundsCheckFrames = Math.max(
+          0,
+          this._worldTransformBoundsCheckFrames - 1,
+        );
+      }
+
       if (changed || boundsChanged) {
         this._onWorldTransformChanged();
       }
     }
 
     destroy(options) {
+      this.off?.('added', this._boundMarkWorldTransformTreeDirty);
+      this.off?.('removed', this._boundMarkWorldTransformTreeDirty);
       this._unregisterWorldTransformSubscriber();
       super.destroy(options);
     }

--- a/src/display/mixins/WorldTransformable.test.js
+++ b/src/display/mixins/WorldTransformable.test.js
@@ -52,10 +52,7 @@ class MockBase {
     };
     this.angle = 0;
     this._bounds = { x: 0, y: 0, width: 100, height: 20 };
-  }
-
-  getLocalBounds() {
-    return this._bounds;
+    this.getLocalBounds = vi.fn(() => this._bounds);
   }
 
   setBounds(nextBounds) {
@@ -109,6 +106,90 @@ describe('WorldTransformable', () => {
 
     instance.setBounds({ x: 0, y: 0, width: 140.8, height: 10 });
     instance._afterRender();
+    expect(applyWorldRotation).toHaveBeenCalledTimes(1);
+    expect(applyWorldFlip).toHaveBeenCalledTimes(1);
+    expect(instance._applyPlacement).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips parent chain and bounds polling while the viewport is dragging', () => {
+    const world = {};
+    const viewport = createMockViewport();
+    viewport.moving = false;
+    const parent = { angle: 0, parent: world };
+    const TestClass = WorldTransformable(MockBase);
+    const instance = new TestClass({
+      store: {
+        world,
+        viewport,
+        view: { angle: 0, flipX: false, flipY: false },
+      },
+      parent,
+    });
+    instance._applyPlacement = vi.fn();
+
+    instance._afterRender();
+    instance.getLocalBounds.mockClear();
+    vi.mocked(applyWorldRotation).mockClear();
+    vi.mocked(applyWorldFlip).mockClear();
+    instance._applyPlacement.mockClear();
+
+    viewport.moving = true;
+    for (let i = 0; i < 10; i += 1) {
+      instance._afterRender();
+    }
+
+    expect(instance.getLocalBounds).not.toHaveBeenCalled();
+    expect(applyWorldRotation).not.toHaveBeenCalled();
+    expect(applyWorldFlip).not.toHaveBeenCalled();
+    expect(instance._applyPlacement).not.toHaveBeenCalled();
+
+    viewport.moving = false;
+    instance.setBounds({ x: 0, y: 0, width: 120, height: 20 });
+    instance._afterRender();
+
+    expect(instance.getLocalBounds).toHaveBeenCalledTimes(1);
+    expect(applyWorldRotation).toHaveBeenCalledTimes(1);
+    expect(applyWorldFlip).toHaveBeenCalledTimes(1);
+    expect(instance._applyPlacement).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops polling bounds after the world transform settles', () => {
+    const world = {};
+    const viewport = createMockViewport();
+    const parent = { angle: 0, parent: world };
+    const TestClass = WorldTransformable(MockBase);
+    const instance = new TestClass({
+      store: {
+        world,
+        viewport,
+        view: { angle: 0, flipX: false, flipY: false },
+      },
+      parent,
+    });
+    instance._applyPlacement = vi.fn();
+
+    instance._afterRender();
+    instance._afterRender();
+    instance._afterRender();
+    instance.getLocalBounds.mockClear();
+    vi.mocked(applyWorldRotation).mockClear();
+    vi.mocked(applyWorldFlip).mockClear();
+    instance._applyPlacement.mockClear();
+
+    for (let i = 0; i < 10; i += 1) {
+      instance._afterRender();
+    }
+
+    expect(instance.getLocalBounds).not.toHaveBeenCalled();
+    expect(applyWorldRotation).not.toHaveBeenCalled();
+    expect(applyWorldFlip).not.toHaveBeenCalled();
+    expect(instance._applyPlacement).not.toHaveBeenCalled();
+
+    instance.setBounds({ x: 0, y: 0, width: 130, height: 20 });
+    instance._markWorldTransformBoundsDirty();
+    instance._afterRender();
+
+    expect(instance.getLocalBounds).toHaveBeenCalledTimes(1);
     expect(applyWorldRotation).toHaveBeenCalledTimes(1);
     expect(applyWorldFlip).toHaveBeenCalledTimes(1);
     expect(instance._applyPlacement).toHaveBeenCalledTimes(1);

--- a/src/events/find-helpers.js
+++ b/src/events/find-helpers.js
@@ -9,9 +9,14 @@ export const collectPointHit = ({
   candidates,
   point,
   intersectsPoint,
+  mayContainPoint = () => true,
   resolveSelection = selectCandidate,
 }) => {
   for (const candidate of candidates) {
+    if (!mayContainPoint(candidate, point)) {
+      continue;
+    }
+
     const targets = getTargets(candidate);
 
     for (const target of targets) {
@@ -33,11 +38,16 @@ export const collectPolygonHits = ({
   candidates,
   polygon,
   intersectsPolygon,
+  mayIntersectPolygon = () => true,
   resolveSelection = selectCandidate,
 }) => {
   const found = [];
 
   for (const candidate of candidates) {
+    if (!mayIntersectPolygon(candidate, polygon)) {
+      continue;
+    }
+
     const targets = getTargets(candidate);
 
     for (const target of targets) {

--- a/src/events/find.js
+++ b/src/events/find.js
@@ -3,10 +3,19 @@ import {
   isInteractionLocked,
   isSelectableCandidate,
 } from '../utils/interaction-locks';
-import { intersect } from '../utils/intersects/intersect';
+import {
+  boundsContainPoint,
+  boundsIntersect,
+  getFlatBounds,
+  intersectLocalPoints,
+  toFlatPoints,
+} from '../utils/intersects/intersect';
 import { intersectPoint } from '../utils/intersects/intersect-point';
 import { getSegmentEntryT } from '../utils/intersects/segment-polygon-t';
-import { getObjectLocalCorners } from '../utils/transform';
+import {
+  getObjectLocalCorners,
+  getObjectSizeLocalBounds,
+} from '../utils/transform';
 import {
   collectPointHit,
   collectPolygonHits,
@@ -14,16 +23,25 @@ import {
 } from './find-helpers';
 import { getSelectObject } from './utils';
 
-const getSelectableCandidates = (parent) => {
+const getSelectableCandidates = (parent, config = {}) => {
   if (isInteractionLocked(parent)) {
     return [];
   }
 
   return collectCandidates(
     parent,
-    (child) => isSelectableCandidate(child, parent),
+    (child) =>
+      isSelectableCandidate(child, parent) &&
+      canResolveCandidate(child, config),
     { shouldDescend: (child) => !isInteractionLocked(child, parent) },
   );
+};
+
+const canResolveCandidate = (candidate, { filter, selectUnit } = {}) => {
+  if (selectUnit !== 'entity' || !filter) {
+    return true;
+  }
+  return filter(candidate);
 };
 
 const createFindSelectionResolver = (
@@ -68,7 +86,8 @@ export const findIntersectObject = (
   point,
   { filter, selectUnit, filterParent } = {},
 ) => {
-  const candidates = getSelectableCandidates(parent);
+  const candidates = getSelectableCandidates(parent, { filter, selectUnit });
+  const mayContainPoint = createCandidatePointBoundsFilter(parent, selectUnit);
   const resolveSelection = createFindSelectionResolver(parent, {
     filter,
     selectUnit,
@@ -81,6 +100,7 @@ export const findIntersectObject = (
     ),
     point,
     intersectsPoint: intersectPoint,
+    mayContainPoint,
     resolveSelection,
   });
 };
@@ -90,7 +110,16 @@ export const findIntersectObjects = (
   selectionBox,
   { filter, selectUnit, filterParent } = {},
 ) => {
-  const candidates = getSelectableCandidates(parent);
+  const candidates = getSelectableCandidates(parent, { filter, selectUnit });
+  const selectionPolygon = toFlatPoints(
+    getObjectLocalCorners(selectionBox, parent),
+  );
+  const selectionBounds = getFlatBounds(selectionPolygon);
+  const mayIntersectPolygon = createCandidatePolygonBoundsFilter(
+    parent,
+    selectUnit,
+    selectionBounds,
+  );
   const resolveSelection = createFindSelectionResolver(parent, {
     filter,
     selectUnit,
@@ -98,8 +127,10 @@ export const findIntersectObjects = (
   });
   return collectPolygonHits({
     candidates,
-    polygon: selectionBox,
-    intersectsPolygon: intersect,
+    polygon: selectionPolygon,
+    intersectsPolygon: (polygon, target) =>
+      intersectLocalPoints(polygon, target, parent),
+    mayIntersectPolygon,
     resolveSelection,
   });
 };
@@ -110,7 +141,7 @@ export const findIntersectObjectsBySegment = (
   p2,
   { filter, selectUnit, filterParent } = {},
 ) => {
-  const candidates = getSelectableCandidates(parent);
+  const candidates = getSelectableCandidates(parent, { filter, selectUnit });
   const resolveSelection = createFindSelectionResolver(parent, {
     filter,
     selectUnit,
@@ -134,4 +165,29 @@ const getAncestorPath = (obj, stopAt) => {
     current = current.parent;
   }
   return path;
+};
+
+const createCandidatePointBoundsFilter = (viewport, selectUnit) => {
+  if (selectUnit !== 'entity') {
+    return undefined;
+  }
+
+  return (candidate, point) =>
+    boundsContainPoint(getObjectSizeLocalBounds(candidate, viewport), point);
+};
+
+const createCandidatePolygonBoundsFilter = (
+  viewport,
+  selectUnit,
+  selectionBounds,
+) => {
+  if (selectUnit !== 'entity') {
+    return undefined;
+  }
+
+  return (candidate) =>
+    boundsIntersect(
+      selectionBounds,
+      getObjectSizeLocalBounds(candidate, viewport),
+    );
 };

--- a/src/events/find.test.js
+++ b/src/events/find.test.js
@@ -5,7 +5,35 @@ vi.mock('../utils/intersects/intersect-point', () => ({
 }));
 
 vi.mock('../utils/intersects/intersect', () => ({
+  boundsContainPoint: vi.fn(
+    (bounds, point) =>
+      !bounds ||
+      (point.x >= bounds.minX &&
+        point.x <= bounds.maxX &&
+        point.y >= bounds.minY &&
+        point.y <= bounds.maxY),
+  ),
+  boundsIntersect: vi.fn(
+    (left, right) =>
+      !left ||
+      !right ||
+      (left.minX <= right.maxX &&
+        left.maxX >= right.minX &&
+        left.minY <= right.maxY &&
+        left.maxY >= right.minY),
+  ),
+  getFlatBounds: vi.fn((points) => {
+    if (!points.length) return null;
+    return {
+      minX: Math.min(...points.filter((_, index) => index % 2 === 0)),
+      minY: Math.min(...points.filter((_, index) => index % 2 === 1)),
+      maxX: Math.max(...points.filter((_, index) => index % 2 === 0)),
+      maxY: Math.max(...points.filter((_, index) => index % 2 === 1)),
+    };
+  }),
   intersect: vi.fn((_selectionBox, target) => Boolean(target.hit)),
+  intersectLocalPoints: vi.fn((_selectionBox, target) => Boolean(target.hit)),
+  toFlatPoints: vi.fn(() => []),
 }));
 
 vi.mock('../utils/intersects/segment-polygon-t', () => ({
@@ -16,8 +44,15 @@ vi.mock('../utils/intersects/segment-polygon-t', () => ({
 
 vi.mock('../utils/transform', () => ({
   getObjectLocalCorners: vi.fn(() => []),
+  getObjectSizeLocalBounds: vi.fn(() => null),
 }));
 
+import {
+  intersectLocalPoints,
+  toFlatPoints,
+} from '../utils/intersects/intersect';
+import { intersectPoint } from '../utils/intersects/intersect-point';
+import { getObjectSizeLocalBounds } from '../utils/transform';
 import {
   findIntersectObject,
   findIntersectObjects,
@@ -60,6 +95,8 @@ const createNode = ({
 describe('findIntersectObject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getObjectSizeLocalBounds).mockReturnValue(null);
+    vi.mocked(toFlatPoints).mockReturnValue([]);
   });
 
   it('should return null when the search root itself is locked', () => {
@@ -154,11 +191,86 @@ describe('findIntersectObject', () => {
 
     expect(result).toBe(group);
   });
+
+  it('should skip filtered entity candidates before point hit-testing', () => {
+    const skippedChild = createNode({
+      id: 'skipped-child',
+      type: 'rect',
+      hit: true,
+    });
+    const target = createNode({
+      id: 'target',
+      type: 'item',
+      hit: true,
+    });
+    const root = createNode({
+      id: 'canvas',
+      type: 'canvas',
+      isSelectable: false,
+      children: [skippedChild, target],
+    });
+
+    const result = findIntersectObject(
+      root,
+      { x: 0, y: 0 },
+      {
+        selectUnit: 'entity',
+        filter: (candidate) => candidate.type === 'item',
+      },
+    );
+
+    expect(result).toBe(target);
+    expect(intersectPoint).not.toHaveBeenCalledWith(
+      skippedChild,
+      expect.anything(),
+    );
+  });
+
+  it('should skip out-of-bounds entity candidates before point hit-testing', () => {
+    const farTarget = createNode({
+      id: 'far-target',
+      type: 'item',
+      hit: true,
+    });
+    const target = createNode({
+      id: 'target',
+      type: 'item',
+      hit: true,
+    });
+    const root = createNode({
+      id: 'canvas',
+      type: 'canvas',
+      isSelectable: false,
+      children: [target, farTarget],
+    });
+    vi.mocked(getObjectSizeLocalBounds).mockImplementation((candidate) =>
+      candidate === farTarget
+        ? { minX: 0, minY: 0, maxX: 10, maxY: 10 }
+        : { minX: 40, minY: 40, maxX: 60, maxY: 60 },
+    );
+
+    const result = findIntersectObject(
+      root,
+      { x: 50, y: 50 },
+      {
+        selectUnit: 'entity',
+        filter: (candidate) => candidate.type === 'item',
+      },
+    );
+
+    expect(result).toBe(target);
+    expect(intersectPoint).not.toHaveBeenCalledWith(
+      farTarget,
+      expect.anything(),
+    );
+  });
 });
 
 describe('findIntersectObjects', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getObjectSizeLocalBounds).mockReturnValue(null);
+    vi.mocked(toFlatPoints).mockReturnValue([]);
   });
 
   it('should return an empty list when the search root itself is locked', () => {
@@ -200,11 +312,89 @@ describe('findIntersectObjects', () => {
 
     expect(result).toEqual([unlockedRect]);
   });
+
+  it('should skip filtered entity candidates before final box hit-testing', () => {
+    const skippedChild = createNode({
+      id: 'skipped-child',
+      type: 'rect',
+      hit: true,
+    });
+    const target = createNode({
+      id: 'target',
+      type: 'item',
+      hit: true,
+    });
+    const root = createNode({
+      id: 'canvas',
+      type: 'canvas',
+      isSelectable: false,
+      children: [skippedChild, target],
+    });
+
+    const result = findIntersectObjects(
+      root,
+      {},
+      {
+        selectUnit: 'entity',
+        filter: (candidate) => candidate.type === 'item',
+      },
+    );
+
+    expect(result).toEqual([target]);
+    expect(intersectLocalPoints).not.toHaveBeenCalledWith(
+      expect.anything(),
+      skippedChild,
+      expect.anything(),
+    );
+  });
+
+  it('should skip out-of-bounds entity candidates before final box hit-testing', () => {
+    const farTarget = createNode({
+      id: 'far-target',
+      type: 'item',
+      hit: true,
+    });
+    const target = createNode({
+      id: 'target',
+      type: 'item',
+      hit: true,
+    });
+    const root = createNode({
+      id: 'canvas',
+      type: 'canvas',
+      isSelectable: false,
+      children: [target, farTarget],
+    });
+    vi.mocked(getObjectSizeLocalBounds).mockImplementation((candidate) =>
+      candidate === farTarget
+        ? { minX: 0, minY: 0, maxX: 10, maxY: 10 }
+        : { minX: 40, minY: 40, maxX: 60, maxY: 60 },
+    );
+    vi.mocked(toFlatPoints).mockReturnValue([45, 45, 55, 45, 55, 55, 45, 55]);
+
+    const result = findIntersectObjects(
+      root,
+      {},
+      {
+        selectUnit: 'entity',
+        filter: (candidate) => candidate.type === 'item',
+      },
+    );
+
+    expect(result).toEqual([target]);
+    expect(intersectLocalPoints).not.toHaveBeenCalledWith(
+      expect.anything(),
+      farTarget,
+      expect.anything(),
+    );
+  });
 });
 
 describe('findIntersectObjectsBySegment', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getObjectSizeLocalBounds).mockReturnValue(null);
+    vi.mocked(toFlatPoints).mockReturnValue([]);
   });
 
   it('should return an empty list when the search root itself is locked', () => {

--- a/src/events/states/SelectionState.js
+++ b/src/events/states/SelectionState.js
@@ -621,7 +621,10 @@ const normalizeCssHex = (color) => {
       .map((digit) => `${digit}${digit}`)
       .join('')}`;
   }
-  return `#${value.padStart(6, '0')}`;
+  if (value.length === 6) {
+    return `#${value}`;
+  }
+  return null;
 };
 
 const getPixelLineWidth = (ratio) => 1 / Math.max(ratio || 1, 1);

--- a/src/events/states/SelectionState.js
+++ b/src/events/states/SelectionState.js
@@ -16,6 +16,7 @@ const stateSymbol = {
 };
 
 const VIEWPORT_CHANGE_EPSILON = 0.0001;
+const noop = () => {};
 
 /**
  * @typedef {object} SelectionStateConfig
@@ -73,10 +74,10 @@ const defaultConfig = {
   onClick: () => {},
   onDoubleClick: () => {},
   onRightClick: () => {},
-  onDragStart: () => {},
-  onDrag: () => {},
-  onDragEnd: () => {},
-  onOver: () => {},
+  onDragStart: noop,
+  onDrag: noop,
+  onDragEnd: noop,
+  onOver: noop,
   selectionBoxStyle: {
     fill: { color: '#9FD6FF', alpha: 0.2 },
     stroke: { width: 2, color: '#1099FF' },
@@ -103,6 +104,10 @@ export default class SelectionState extends State {
   movedViewport = false;
   viewportSnapshot = null;
   _selectionBox = new Graphics();
+  _selectionBoxFrame = null;
+  _pendingSelectionBox = null;
+  _latestSelectionBox = null;
+  _selectionBoxOverlay = null;
 
   _paintedObjects = new Set();
   _lastPaintPoint = null;
@@ -122,6 +127,7 @@ export default class SelectionState extends State {
   exit() {
     super.exit();
     this.#clear({ state: true, selectionBox: true, gesture: true });
+    this.#destroySelectionBoxOverlay();
     if (this._selectionBox.parent) {
       this._selectionBox.parent.removeChild(this._selectionBox);
     }
@@ -166,14 +172,22 @@ export default class SelectionState extends State {
       this.interactionState = this.config.paintSelection
         ? stateSymbol.PAINTING
         : stateSymbol.DRAGGING;
+      this.#setObjectAfterRenderSuspended(
+        this.interactionState === stateSymbol.DRAGGING &&
+          !this.#hasCustomHandler('onDrag'),
+      );
       this.viewport.plugin.start('mouse-edges');
       this.config.onDragStart(e);
     }
 
     if (this.interactionState === stateSymbol.DRAGGING) {
-      this.#drawSelectionBox(this.dragStartPoint, currentPoint);
-      const selected = this.#searchObjects(this._selectionBox);
-      this.config.onDrag(selected, e);
+      if (this.#hasCustomHandler('onDrag')) {
+        this.#drawSelectionBox(this.dragStartPoint, currentPoint);
+        const selected = this.#searchObjects(this._selectionBox);
+        this.config.onDrag(selected, e);
+      } else {
+        this.#scheduleSelectionBoxDraw(this.dragStartPoint, currentPoint);
+      }
     } else if (this.interactionState === stateSymbol.PAINTING) {
       const targets = findIntersectObjectsBySegment(
         this.viewport,
@@ -198,6 +212,7 @@ export default class SelectionState extends State {
       const target = this.#searchObject(this.viewport.toWorld(e.global), e);
       this.config.onUp(target, e);
     } else if (this.interactionState === stateSymbol.DRAGGING) {
+      this.#flushSelectionBoxDraw();
       const selected = this.#searchObjects(this._selectionBox);
       this.config.onDragEnd(selected, e);
       this.viewport.plugin.stop('mouse-edges');
@@ -210,6 +225,7 @@ export default class SelectionState extends State {
 
   onpointerover(e) {
     if (this.interactionState !== stateSymbol.IDLE) return;
+    if (!this.#hasCustomHandler('onOver')) return;
     const target = this.#searchObject(this.viewport.toWorld(e.global), e);
     this.config.onOver(target, e);
   }
@@ -362,14 +378,18 @@ export default class SelectionState extends State {
   #clear({ state = false, selectionBox = false, gesture = false }) {
     if (state) {
       this.interactionState = stateSymbol.IDLE;
+      this.#setObjectAfterRenderSuspended(false);
     }
     if (selectionBox && !this._selectionBox.destroyed) {
+      this.#cancelSelectionBoxDraw();
+      this.#hideSelectionBoxOverlay();
       this._selectionBox.clear();
     }
     if (gesture) {
       this.dragStartPoint = null;
       this.movedViewport = false;
       this.viewportSnapshot = null;
+      this._latestSelectionBox = null;
       this._paintedObjects.clear();
       this._lastPaintPoint = null;
     }
@@ -397,4 +417,222 @@ export default class SelectionState extends State {
         VIEWPORT_CHANGE_EPSILON
     );
   }
+
+  #hasCustomHandler(key) {
+    return this.config[key] !== defaultConfig[key];
+  }
+
+  #setObjectAfterRenderSuspended(value) {
+    if (this.viewport) {
+      this.viewport._suspendObjectAfterRender = value;
+    }
+  }
+
+  #scheduleSelectionBoxDraw(p1, p2) {
+    this._pendingSelectionBox = { p1, p2 };
+    this._latestSelectionBox = this._pendingSelectionBox;
+    if (this._selectionBoxFrame !== null) return;
+
+    const requestFrame =
+      globalThis.requestAnimationFrame ??
+      ((callback) => globalThis.setTimeout(callback, 16));
+    this._selectionBoxFrame = requestFrame(() => {
+      this._selectionBoxFrame = null;
+      this.#flushSelectionBoxOverlay();
+    });
+  }
+
+  #flushSelectionBoxDraw() {
+    const pending = this._pendingSelectionBox ?? this._latestSelectionBox;
+    this._pendingSelectionBox = null;
+    if (pending) {
+      this.#drawSelectionBox(pending.p1, pending.p2);
+    }
+  }
+
+  #cancelSelectionBoxDraw() {
+    if (this._selectionBoxFrame === null) return;
+
+    const cancelFrame =
+      globalThis.cancelAnimationFrame ?? globalThis.clearTimeout;
+    cancelFrame?.(this._selectionBoxFrame);
+    this._selectionBoxFrame = null;
+    this._pendingSelectionBox = null;
+  }
+
+  #flushSelectionBoxOverlay() {
+    const pending = this._pendingSelectionBox;
+    this._pendingSelectionBox = null;
+    if (pending) {
+      this.#drawSelectionBoxOverlay(pending.p1, pending.p2);
+    }
+  }
+
+  #drawSelectionBoxOverlay(p1, p2) {
+    const overlay = this.#getSelectionBoxOverlay();
+    if (!overlay || !p1 || !p2) {
+      return;
+    }
+
+    const start = this.viewport.toGlobal(p1);
+    const end = this.viewport.toGlobal(p2);
+    const left = Math.min(start.x, end.x);
+    const top = Math.min(start.y, end.y);
+    const width = Math.abs(start.x - end.x);
+    const height = Math.abs(start.y - end.y);
+    const { fill, stroke } = this.config.selectionBoxStyle;
+
+    this.#resizeSelectionBoxOverlay(overlay);
+    const strokeWidth = getPixelLineWidth(overlay.ratio);
+    const rect = alignPixelLineRect(
+      { left, top, width, height },
+      strokeWidth,
+      overlay.ratio,
+    );
+
+    overlay.canvas.style.display = 'block';
+    overlay.context.clearRect(
+      0,
+      0,
+      overlay.canvas.width,
+      overlay.canvas.height,
+    );
+    overlay.context.save();
+    overlay.context.scale(overlay.ratio, overlay.ratio);
+    overlay.context.fillStyle = toCssColor(fill.color, fill.alpha);
+    overlay.context.strokeStyle = toCssColor(stroke.color, stroke.alpha);
+    overlay.context.lineWidth = strokeWidth;
+    overlay.context.fillRect(rect.left, rect.top, rect.width, rect.height);
+    overlay.context.strokeRect(
+      rect.left + strokeWidth / 2,
+      rect.top + strokeWidth / 2,
+      Math.max(rect.width - strokeWidth, 0),
+      Math.max(rect.height - strokeWidth, 0),
+    );
+    overlay.context.restore();
+  }
+
+  #getSelectionBoxOverlay() {
+    if (this._selectionBoxOverlay?.canvas?.isConnected) {
+      return this._selectionBoxOverlay;
+    }
+    if (typeof document === 'undefined') {
+      return null;
+    }
+
+    const parent = this.viewport?.app?.canvas?.parentElement;
+    if (!parent) {
+      return null;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.style.position = 'absolute';
+    canvas.style.inset = '0';
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    canvas.style.pointerEvents = 'none';
+    canvas.style.display = 'none';
+    if (getComputedStyle(parent).position === 'static') {
+      parent.style.position = 'relative';
+    }
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return null;
+    }
+    parent.appendChild(canvas);
+    this._selectionBoxOverlay = {
+      canvas,
+      context,
+      ratio: 1,
+      width: 0,
+      height: 0,
+    };
+    return this._selectionBoxOverlay;
+  }
+
+  #resizeSelectionBoxOverlay(overlay) {
+    const width = this.viewport?.app?.screen?.width ?? 0;
+    const height = this.viewport?.app?.screen?.height ?? 0;
+    const ratio = globalThis.devicePixelRatio || 1;
+    if (
+      overlay.width === width &&
+      overlay.height === height &&
+      overlay.ratio === ratio
+    ) {
+      return;
+    }
+
+    overlay.width = width;
+    overlay.height = height;
+    overlay.ratio = ratio;
+    overlay.canvas.width = Math.max(Math.ceil(width * ratio), 1);
+    overlay.canvas.height = Math.max(Math.ceil(height * ratio), 1);
+  }
+
+  #hideSelectionBoxOverlay() {
+    if (this._selectionBoxOverlay?.canvas) {
+      this._selectionBoxOverlay.context.clearRect(
+        0,
+        0,
+        this._selectionBoxOverlay.canvas.width,
+        this._selectionBoxOverlay.canvas.height,
+      );
+      this._selectionBoxOverlay.canvas.style.display = 'none';
+    }
+  }
+
+  #destroySelectionBoxOverlay() {
+    this._selectionBoxOverlay?.canvas?.remove();
+    this._selectionBoxOverlay = null;
+  }
 }
+
+const toCssColor = (color, alpha) => {
+  const hex = normalizeCssHex(color);
+  if (alpha == null || !hex) {
+    return hex ?? color;
+  }
+
+  const value = hex.slice(1);
+  const r = parseInt(value.slice(0, 2), 16);
+  const g = parseInt(value.slice(2, 4), 16);
+  const b = parseInt(value.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+const normalizeCssHex = (color) => {
+  if (typeof color === 'number') {
+    return `#${color.toString(16).padStart(6, '0')}`;
+  }
+  if (typeof color !== 'string') {
+    return null;
+  }
+  if (color.startsWith('#')) {
+    return color;
+  }
+  if (color.startsWith('0x')) {
+    return `#${color.slice(2).padStart(6, '0')}`;
+  }
+  return null;
+};
+
+const getPixelLineWidth = (ratio) => 1 / Math.max(ratio || 1, 1);
+
+const alignPixelLineRect = (
+  { left, top, width, height },
+  strokeWidth,
+  ratio,
+) => {
+  const unit = 1 / Math.max(ratio || 1, 1);
+  const alignedLeft = Math.round(left / unit) * unit;
+  const alignedTop = Math.round(top / unit) * unit;
+  const alignedRight = Math.round((left + width) / unit) * unit;
+  const alignedBottom = Math.round((top + height) / unit) * unit;
+
+  return {
+    left: alignedLeft,
+    top: alignedTop,
+    width: Math.max(alignedRight - alignedLeft, strokeWidth),
+    height: Math.max(alignedBottom - alignedTop, strokeWidth),
+  };
+};

--- a/src/events/states/SelectionState.js
+++ b/src/events/states/SelectionState.js
@@ -607,13 +607,21 @@ const normalizeCssHex = (color) => {
   if (typeof color !== 'string') {
     return null;
   }
-  if (color.startsWith('#')) {
-    return color;
+  const value = color.startsWith('#')
+    ? color.slice(1)
+    : color.startsWith('0x')
+      ? color.slice(2)
+      : null;
+  if (!value) {
+    return null;
   }
-  if (color.startsWith('0x')) {
-    return `#${color.slice(2).padStart(6, '0')}`;
+  if (value.length === 3) {
+    return `#${value
+      .split('')
+      .map((digit) => `${digit}${digit}`)
+      .join('')}`;
   }
-  return null;
+  return `#${value.padStart(6, '0')}`;
 };
 
 const getPixelLineWidth = (ratio) => 1 / Math.max(ratio || 1, 1);

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -1415,6 +1415,44 @@ describe('patchmap test', () => {
         expect(viewport._suspendObjectAfterRender).toBe(false);
       });
 
+      it('renders deferred selection boxes with short hex colors', async () => {
+        patchmap.stateManager.setState('selection', {
+          enabled: true,
+          draggable: true,
+          selectionBoxStyle: {
+            fill: { color: '#fff', alpha: 0.5 },
+            stroke: { width: 1, color: '#000' },
+          },
+        });
+
+        const viewport = patchmap.viewport;
+        viewport.plugin.stop('drag');
+        emitPointer(viewport, 'pointerdown', { x: 0, y: 0 });
+        emitPointer(viewport, 'pointermove', { x: 100, y: 100 });
+
+        await vi.advanceTimersByTimeAsync(20);
+
+        const overlay = [...document.querySelectorAll('canvas')].find(
+          (canvas) => canvas.style.pointerEvents === 'none',
+        );
+        const ratio = globalThis.devicePixelRatio || 1;
+        const pixel = overlay
+          ?.getContext('2d')
+          ?.getImageData(
+            Math.round(50 * ratio),
+            Math.round(50 * ratio),
+            1,
+            1,
+          ).data;
+
+        expect(pixel?.[0]).toBeGreaterThan(200);
+        expect(pixel?.[1]).toBeGreaterThan(200);
+        expect(pixel?.[2]).toBeGreaterThan(200);
+        expect(pixel?.[3]).toBeGreaterThan(0);
+
+        emitPointer(viewport, 'pointerup', { x: 100, y: 100 });
+      });
+
       it('skips pointerover hit-testing when onOver is not configured', () => {
         const filter = vi.fn(() => true);
 

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -1321,5 +1321,157 @@ describe('patchmap test', () => {
         }
       });
     });
+
+    describe('drag and hover performance guards', () => {
+      const emitPointer = (viewport, type, position, extras = {}) => {
+        viewport.emit(type, {
+          global: viewport.toGlobal(position),
+          button: 0,
+          buttons: type === 'pointerup' ? 0 : 1,
+          pointerId: 1,
+          pointerType: 'mouse',
+          data: { pointerId: 1, pointerType: 'mouse' },
+          stopPropagation: () => {},
+          ...extras,
+        });
+      };
+
+      it('skips drag hit-testing during pointermove when onDrag is not configured', () => {
+        const filter = vi.fn(() => true);
+        const onDragEnd = vi.fn();
+
+        patchmap.stateManager.setState('selection', {
+          enabled: true,
+          draggable: true,
+          selectUnit: 'entity',
+          filter,
+          onDragEnd,
+        });
+
+        const viewport = patchmap.viewport;
+        viewport.plugin.stop('drag');
+        emitPointer(viewport, 'pointerdown', { x: 0, y: 0 });
+        filter.mockClear();
+
+        emitPointer(viewport, 'pointermove', { x: 230, y: 230 });
+
+        expect(filter).not.toHaveBeenCalled();
+        expect(viewport._suspendObjectAfterRender).toBe(true);
+
+        emitPointer(viewport, 'pointerup', { x: 230, y: 230 });
+
+        expect(filter).toHaveBeenCalled();
+        expect(onDragEnd).toHaveBeenCalledTimes(1);
+        expect(viewport._suspendObjectAfterRender).toBe(false);
+      });
+
+      it('finishes shift box selection on pointerup without testing filtered entity children', () => {
+        const filter = vi.fn((target) => target.type === 'item');
+        const onDragEnd = vi.fn();
+
+        patchmap.stateManager.setState('selection', {
+          enabled: true,
+          draggable: true,
+          selectUnit: 'entity',
+          filter,
+          onDragEnd,
+        });
+
+        const viewport = patchmap.viewport;
+        viewport.plugin.stop('drag');
+        emitPointer(viewport, 'pointerdown', { x: 0, y: 0 });
+        emitPointer(viewport, 'pointermove', { x: 230, y: 230 });
+        filter.mockClear();
+
+        emitPointer(viewport, 'pointerup', { x: 230, y: 230 });
+
+        expect(onDragEnd).toHaveBeenCalledTimes(1);
+        expect(
+          onDragEnd.mock.calls[0][0].every((target) => target.type === 'item'),
+        ).toBe(true);
+      });
+
+      it('keeps live drag hit-testing when onDrag is configured', () => {
+        const filter = vi.fn(() => true);
+        const onDrag = vi.fn();
+
+        patchmap.stateManager.setState('selection', {
+          enabled: true,
+          draggable: true,
+          selectUnit: 'entity',
+          filter,
+          onDrag,
+        });
+
+        const viewport = patchmap.viewport;
+        viewport.plugin.stop('drag');
+        emitPointer(viewport, 'pointerdown', { x: 0, y: 0 });
+        filter.mockClear();
+
+        emitPointer(viewport, 'pointermove', { x: 230, y: 230 });
+
+        expect(filter).toHaveBeenCalled();
+        expect(onDrag).toHaveBeenCalledTimes(1);
+        expect(viewport._suspendObjectAfterRender).toBe(false);
+      });
+
+      it('skips pointerover hit-testing when onOver is not configured', () => {
+        const filter = vi.fn(() => true);
+
+        patchmap.stateManager.setState('selection', {
+          enabled: true,
+          selectUnit: 'entity',
+          filter,
+        });
+
+        emitPointer(patchmap.viewport, 'pointerover', { x: 105, y: 105 });
+
+        expect(filter).not.toHaveBeenCalled();
+      });
+
+      it('keeps pointerover hit-testing when onOver is configured', () => {
+        const filter = vi.fn(() => true);
+        const onOver = vi.fn();
+
+        patchmap.stateManager.setState('selection', {
+          enabled: true,
+          selectUnit: 'entity',
+          filter,
+          onOver,
+        });
+
+        emitPointer(patchmap.viewport, 'pointerover', { x: 105, y: 105 });
+
+        expect(filter).toHaveBeenCalled();
+        expect(onOver).toHaveBeenCalledTimes(1);
+        expect(onOver.mock.calls[0][0]?.id).toBe('grid-1.0.0');
+      });
+
+      it('dispatches empty-area double-click as onDoubleClick(null)', () => {
+        const filter = vi.fn((target) => target.type === 'item');
+        const onClick = vi.fn();
+        const onDoubleClick = vi.fn();
+
+        patchmap.stateManager.setState('selection', {
+          enabled: true,
+          selectUnit: 'entity',
+          filter,
+          onClick,
+          onDoubleClick,
+        });
+
+        patchmap.viewport.emit('click', {
+          detail: 2,
+          global: patchmap.viewport.toGlobal({ x: 0, y: 0 }),
+          stopPropagation: () => {},
+        });
+
+        expect(onDoubleClick).toHaveBeenCalledWith(
+          null,
+          expect.objectContaining({ detail: 2 }),
+        );
+        expect(onClick).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/src/utils/intersects/intersect.js
+++ b/src/utils/intersects/intersect.js
@@ -6,14 +6,53 @@ export const intersect = (obj1, obj2) => {
   const viewport = getViewport(obj2) ?? getViewport(obj1);
   if (!viewport) return false;
 
-  const points1 = getObjectLocalCorners(obj1, viewport).flatMap((point) => [
-    point.x,
-    point.y,
-  ]);
-  const points2 = getObjectLocalCorners(obj2, viewport).flatMap((point) => [
-    point.x,
-    point.y,
-  ]);
+  const points1 = toFlatPoints(getObjectLocalCorners(obj1, viewport));
+  return intersectLocalPoints(points1, obj2, viewport);
+};
 
+export const intersectLocalPoints = (points1, obj2, viewport) => {
+  const points2 = toFlatPoints(getObjectLocalCorners(obj2, viewport));
+  if (!boundsIntersect(getFlatBounds(points1), getFlatBounds(points2))) {
+    return false;
+  }
   return sat(points1, points2);
 };
+
+export const toFlatPoints = (points) =>
+  points.flatMap((point) => [point.x, point.y]);
+
+export const getFlatBounds = (points) => {
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (let i = 0; i < points.length; i += 2) {
+    const x = points[i];
+    const y = points[i + 1];
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x);
+    maxY = Math.max(maxY, y);
+  }
+
+  if (minX === Number.POSITIVE_INFINITY) {
+    return null;
+  }
+  return { minX, minY, maxX, maxY };
+};
+
+export const boundsContainPoint = (bounds, point) =>
+  !bounds ||
+  (point.x >= bounds.minX &&
+    point.x <= bounds.maxX &&
+    point.y >= bounds.minY &&
+    point.y <= bounds.maxY);
+
+export const boundsIntersect = (left, right) =>
+  !left ||
+  !right ||
+  (left.minX <= right.maxX &&
+    left.maxX >= right.minX &&
+    left.minY <= right.maxY &&
+    left.maxY >= right.minY);

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -5,6 +5,7 @@ const FRAME_BOUNDS_OPTIONS = { useSizeFallback: true };
 
 // A temporary array of points to be reused across calculations, avoiding frequent object allocation.
 const tempCorners = [new Point(), new Point(), new Point(), new Point()];
+const tempPoint = new Point();
 
 /**
  * Calculates the four corners of a DisplayObject in world space.
@@ -110,6 +111,36 @@ export const getObjectLocalCorners = (
 
 export const getObjectFrameLocalCorners = (displayObject, viewport) =>
   getObjectLocalCorners(displayObject, viewport, FRAME_BOUNDS_OPTIONS);
+
+export const getObjectSizeLocalBounds = (displayObject, viewport) => {
+  const size = normalizeSize(displayObject?.props?.size);
+  if (!size || !viewport) {
+    return null;
+  }
+
+  const worldTransform = displayObject.getGlobalTransform(tempMatrix, false);
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  for (const point of [
+    { x: 0, y: 0 },
+    { x: size.width, y: 0 },
+    { x: size.width, y: size.height },
+    { x: 0, y: size.height },
+  ]) {
+    tempPoint.set(point.x, point.y);
+    worldTransform.apply(tempPoint, tempPoint);
+    const local = viewport.toLocal(tempPoint);
+    minX = Math.min(minX, local.x);
+    minY = Math.min(minY, local.y);
+    maxX = Math.max(maxX, local.x);
+    maxY = Math.max(maxY, local.y);
+  }
+
+  return { minX, minY, maxX, maxY };
+};
 
 /**
  * Calculates the geometric center (centroid) of an array of points.


### PR DESCRIPTION
## Summary
- Fixes dashboard drag-selection jank by deferring unnecessary per-move hit-testing and transform work during box selection.
- Adds bounds prefilters for entity selection hit tests and keeps live callbacks intact when consumers opt into `onDrag` / `onOver`.
- Fixes deferred selection-box overlay color parsing for short hex colors like `#fff`.

## Related Issue / Discussion
- Fixes #
- Refs #

## Reproduction (Before Fix)
- Steps: Start a drag-selection gesture over a dense patch map/dashboard while no live `onDrag` handler is configured.
- Actual behavior: pointermove repeatedly hit-tests candidates and object after-render work continues during the drag, causing visible jank.
- Expected behavior: drag box remains responsive, and final selection is resolved on pointerup without paying full per-move selection cost.

## Root Cause
- Selection drag treated every pointermove as a full selection query even when the caller only needed the final `onDragEnd` result.
- Object transform after-render checks and render-group behavior added extra work during viewport/selection movement.
- The deferred DOM canvas overlay reused CSS conversion code that did not expand 3-digit hex colors before building rgba values.

## Fix Strategy
- Key fix approach: defer drag-box drawing/search work when `onDrag` is not configured, suspend object after-render work during that gesture, add cheap bounds prefilters before SAT hit testing, and remove render-group use from patch-map groups.
- Why this fix is safe: existing live behavior is preserved when `onDrag` or `onOver` is provided, final selection still runs on pointerup, and new browser/unit tests cover both optimized and live paths.

## Validation
- [x] `npm run test:unit`
- [x] `npm run build`
- [x] `npm run test:headless` (if UI interaction changed)
- Before fix verification: Reviewed diff against the previous eager pointermove hit-test path and object after-render work.
- After fix verification: `bun run test:unit`, `bun run test:headless src/tests/render/patchmap.test.js`, and `bun run build` passed locally.
- Regression test added/updated: Added unit coverage for bounds-filtered hit tests and browser coverage for drag/hover performance guards plus short-hex overlay rendering.

## Documentation
- [ ] `README.md` updated
- [ ] `README_KR.md` updated
- [x] No documentation update needed

## Release Impact
- [ ] none (internal only)
- [x] patch (backward-compatible bug fix)
- [ ] minor (behavioral addition while fixing)

## Risk / Side Effects
- Impacted area: selection drag/hover interaction, object transform after-render hooks, group rendering, hit testing.
- Potential side effects: consumers relying on per-move drag selection must provide `onDrag`; deferred overlay draws through a DOM canvas rather than the Pixi graphics path during optimized drags.
- Mitigation: browser tests cover default deferred drag, live `onDrag`, `onOver`, pointerup selection, and overlay color rendering.

## Remaining Gaps / Follow-up (Optional)
- Gaps: none known.
- Follow-up tasks: none.
