### PR TITLE
fix(patch-map): preserve normalized text placement updates

### DIFF
--- a/src/display/components/Text.js
+++ b/src/display/components/Text.js
@@ -12,6 +12,7 @@ import { mixins } from '../mixins/utils';
 import { WorldTransformable } from '../mixins/WorldTransformable';
 
 const HANDLER_KEYS = ['text', 'style', 'split', 'attrs'];
+const PLACEMENT_HANDLER_KEYS = [...HANDLER_KEYS, 'placement', 'margin'];
 
 const ComposedText = mixins(
   BitmapText,
@@ -48,4 +49,4 @@ Text.registerHandler(
   Text.prototype._applyWorldTransform,
   UPDATE_STAGES.WORLD_TRANSFORM,
 );
-Text.registerHandler(HANDLER_KEYS, Text.prototype._applyPlacement);
+Text.registerHandler(PLACEMENT_HANDLER_KEYS, Text.prototype._applyPlacement);

--- a/src/display/default-props.js
+++ b/src/display/default-props.js
@@ -90,6 +90,11 @@ const withStrokeStyleDefaults = (style) => ({
   ...(isPlainObject(style) ? style : {}),
 });
 
+const withBoxSpacingDefaults = (value) => ({
+  ...normalizeBoxSpacing(0),
+  ...normalizeBoxSpacing(value),
+});
+
 const withItemLikeDefaults = (value, options = {}) => {
   const { materializeComponents = true } = options;
   let next = value;
@@ -98,6 +103,8 @@ const withItemLikeDefaults = (value, options = {}) => {
   }
   if (next.padding === undefined) {
     next = { ...next, padding: normalizeBoxSpacing(0) };
+  } else {
+    next = { ...next, padding: withBoxSpacingDefaults(next.padding) };
   }
   if (next.contentOrientation === undefined) {
     next = { ...next, contentOrientation: 'upright' };
@@ -192,6 +199,8 @@ export const applyComponentDefaults = (value) => {
       }
       if (next.margin === undefined) {
         next = { ...next, margin: normalizeBoxSpacing(0) };
+      } else {
+        next = { ...next, margin: withBoxSpacingDefaults(next.margin) };
       }
       if (next.animation === undefined) {
         next = { ...next, animation: true };
@@ -206,6 +215,8 @@ export const applyComponentDefaults = (value) => {
       }
       if (next.margin === undefined) {
         next = { ...next, margin: normalizeBoxSpacing(0) };
+      } else {
+        next = { ...next, margin: withBoxSpacingDefaults(next.margin) };
       }
       break;
     case 'text':
@@ -214,6 +225,8 @@ export const applyComponentDefaults = (value) => {
       }
       if (next.margin === undefined) {
         next = { ...next, margin: normalizeBoxSpacing(0) };
+      } else {
+        next = { ...next, margin: withBoxSpacingDefaults(next.margin) };
       }
       if (next.text === undefined) {
         next = { ...next, text: '' };

--- a/src/display/mixins/Childrenable.js
+++ b/src/display/mixins/Childrenable.js
@@ -13,7 +13,7 @@ export const Childrenable = (superClass) => {
     _applyChildren(relevantChanges, options = {}) {
       const childOptions =
         options.validateSchema === false
-          ? { ...options, validateSchema: false, normalize: false }
+          ? { ...options, validateSchema: false }
           : options;
       let childrenChanges = options.refresh
         ? relevantChanges?.children
@@ -79,9 +79,7 @@ export const Childrenable = (superClass) => {
 };
 
 const canUseInitialFastPath = (options) =>
-  options.mergeStrategy === 'replace' &&
-  options.validateSchema === false &&
-  options.normalize === false;
+  options.mergeStrategy === 'replace' && options.validateSchema === false;
 
 const applyInitialChild = (
   element,

--- a/src/display/mixins/Componentsable.js
+++ b/src/display/mixins/Componentsable.js
@@ -14,7 +14,7 @@ export const Componentsable = (superClass) => {
     _applyComponents(relevantChanges, options = {}) {
       const childOptions =
         options.validateSchema === false
-          ? { ...options, validateSchema: false, normalize: false }
+          ? { ...options, validateSchema: false }
           : options;
       let componentsChanges = options.refresh
         ? relevantChanges?.components
@@ -101,9 +101,7 @@ export const Componentsable = (superClass) => {
 };
 
 const canUseInitialFastPath = (options) =>
-  options.mergeStrategy === 'replace' &&
-  options.validateSchema === false &&
-  options.normalize === false;
+  options.mergeStrategy === 'replace' && options.validateSchema === false;
 
 const applyInitialComponent = (
   component,

--- a/src/display/mixins/utils.js
+++ b/src/display/mixins/utils.js
@@ -2,6 +2,7 @@ import gsap from 'gsap';
 import { isValidationError } from 'zod-validation-error';
 import { findIndexByPriority } from '../../utils/findIndexByPriority';
 import { validate } from '../../utils/validator';
+import { normalizeChanges } from '../normalize';
 import { ZERO_MARGIN } from './constants';
 
 export const tweensOf = (object) => gsap.getTweensOf(object);
@@ -197,7 +198,11 @@ export const validateAndPrepareChanges = (
   schema,
   options = {},
 ) => {
-  const preparedChanges = [...changes];
+  const shouldNormalize =
+    options.validateSchema === false && options.normalize !== false;
+  const preparedChanges = shouldNormalize
+    ? changes.map((change) => normalizeChanges(change, change?.type))
+    : [...changes];
   const used = new Set();
   const newElementDefs = [];
   const newElementIndices = [];

--- a/src/display/mixins/utils.test.js
+++ b/src/display/mixins/utils.test.js
@@ -232,8 +232,34 @@ describe('validateAndPrepareChanges', () => {
     ]);
   });
 
+  it('normalizes changes without schema validation by default', () => {
+    const changes = [{ type: 'text', margin: { x: 4, top: -17 } }];
+    const schema = z.array(
+      z.object({
+        type: z.string(),
+        margin: z.object({
+          top: z.number(),
+          right: z.number(),
+          bottom: z.number(),
+          left: z.number(),
+        }),
+      }),
+    );
+
+    expect(
+      validateAndPrepareChanges([], changes, schema, {
+        validateSchema: false,
+      }),
+    ).toEqual([
+      {
+        type: 'text',
+        margin: { top: -17, right: 4, left: 4 },
+      },
+    ]);
+  });
+
   it('applies lightweight defaults without schema validation when validateSchema is false', () => {
-    const changes = [{ type: 'text' }];
+    const changes = [{ type: 'text', margin: { top: -17 } }];
     const schema = z.array(
       z.object({
         type: z.string(),
@@ -253,7 +279,7 @@ describe('validateAndPrepareChanges', () => {
         show: true,
         tint: 0xffffff,
         placement: 'center',
-        margin: { top: 0, right: 0, bottom: 0, left: 0 },
+        margin: { top: -17, right: 0, bottom: 0, left: 0 },
         text: '',
         style: {
           fontFamily: 'FiraCode',

--- a/src/tests/render/components/Text.test.js
+++ b/src/tests/render/components/Text.test.js
@@ -48,6 +48,40 @@ describe('Text Component Tests', () => {
     expect(text.text).toBe('Updated Text');
   });
 
+  it('should preserve placement margin when text changes', () => {
+    const patchmap = getPatchmap();
+    patchmap.draw([
+      {
+        type: 'item',
+        id: 'item-with-header-label',
+        size: { width: 60, height: 70 },
+        padding: { left: 4, right: 4, bottom: 4, top: 20 },
+        components: [
+          {
+            type: 'text',
+            id: 'header-label',
+            text: 'INV 1',
+            placement: 'top',
+            margin: { top: -17 },
+            style: { fontSize: 10 },
+          },
+        ],
+      },
+    ]);
+    gsap.exportRoot().totalProgress(1);
+
+    const label = patchmap.selector('$..[?(@.id=="header-label")]')[0];
+    const initialY = label.y;
+
+    patchmap.update({
+      path: '$..[?(@.id=="header-label")]',
+      changes: { text: 'INV 2' },
+    });
+
+    expect(label.y).toBe(initialY);
+    expect(label.y).toBeLessThan(20);
+  });
+
   it('should update style properties', () => {
     const patchmap = getPatchmap();
     patchmap.draw([itemWithText]);
@@ -109,30 +143,31 @@ describe('Text Component Tests', () => {
       },
     ];
 
-    it.each(layoutTestCases)(
-      'should correctly position to $description',
-      ({ itemSize, textPlacement, validate }) => {
-        const patchmap = getPatchmap();
-        const testItem = {
-          type: 'item',
-          id: 'test-item-layout',
-          size: itemSize,
-          components: [
-            {
-              type: 'text',
-              id: 'text-layout',
-              text: 'Layout', // 텍스트가 있어야 너비가 생김
-              placement: textPlacement,
-            },
-          ],
-        };
-        patchmap.draw([testItem]);
-        gsap.exportRoot().totalProgress(1);
+    it.each(layoutTestCases)('should correctly position to $description', ({
+      itemSize,
+      textPlacement,
+      validate,
+    }) => {
+      const patchmap = getPatchmap();
+      const testItem = {
+        type: 'item',
+        id: 'test-item-layout',
+        size: itemSize,
+        components: [
+          {
+            type: 'text',
+            id: 'text-layout',
+            text: 'Layout', // 텍스트가 있어야 너비가 생김
+            placement: textPlacement,
+          },
+        ],
+      };
+      patchmap.draw([testItem]);
+      gsap.exportRoot().totalProgress(1);
 
-        const text = patchmap.selector('$..[?(@.id=="text-layout")]')[0];
-        validate(text, itemSize);
-      },
-    );
+      const text = patchmap.selector('$..[?(@.id=="text-layout")]')[0];
+      validate(text, itemSize);
+    });
   });
 
   it('should correctly split text based on the "split" property', () => {

--- a/src/tests/render/patchmap.test.js
+++ b/src/tests/render/patchmap.test.js
@@ -326,6 +326,36 @@ describe('patchmap test', () => {
     });
   });
 
+  it('normalizes child shorthand updates when schema validation is skipped', () => {
+    const patchmap = getPatchmap();
+    patchmap.draw([{ type: 'group', id: 'normalized-children', children: [] }]);
+
+    patchmap.update({
+      path: '$..[?(@.id=="normalized-children")]',
+      validateSchema: false,
+      changes: {
+        children: [
+          {
+            type: 'item',
+            id: 'child-with-partial-padding',
+            size: 80,
+            padding: { top: 12 },
+          },
+        ],
+      },
+    });
+
+    const child = patchmap.selector(
+      '$..[?(@.id=="child-with-partial-padding")]',
+    )[0];
+    expect(child.props.padding).toEqual({
+      top: 12,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    });
+  });
+
   it('sorts top-level world children by zIndex after draw and update', async () => {
     const patchmap = getPatchmap();
     patchmap.draw([


### PR DESCRIPTION
## Summary
- normalize update changes even when schema validation is skipped
- preserve partial text margin/padding defaults so placement offsets survive text updates
- re-apply text placement when placement or margin changes

## Validation
- npm run test:unit -- src/display/mixins/utils.test.js --run
- npm run test:headless -- --project browser src/tests/render/components/Text.test.js src/tests/render/patchmap.test.js --run