### PR TITLE
feat: support inline AssetSource descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,35 @@ patchmap.draw(data);
 The **data structure** required by draw method.  
 For **detailed type definitions**, refer to the [data.d.ts](src/display/data-schema/data.d.ts) file.
 
+#### AssetSource descriptors
+
+`image.source`, `background.source`, and `icon.source` can use either a string
+asset key/URL or an inline `AssetSource` descriptor. Use a descriptor when a
+URL-backed texture needs Pixi loader options such as SVG `resolution`.
+
+```js
+const svgIcon = {
+  type: 'icon',
+  source: {
+    src: 'https://example.com/icon.svg',
+    data: { resolution: 3 },
+  },
+  tint: 'black',
+  size: 16,
+};
+
+const svgBackground = {
+  type: 'background',
+  source: {
+    src: 'https://example.com/background.svg',
+    data: { resolution: 3 },
+  },
+};
+```
+
+`AssetSource` is for direct URLs or data URIs. Continue to use `init({ assets })`
+and string sources for reusable public aliases.
+
 #### Spacing shorthand
 
 For box-like spacing fields such as component `margin` and element or item `padding`, PATCH MAP normalizes the following inputs in both `draw(data)` and `update({ changes })`:

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ For **detailed type definitions**, refer to the [data.d.ts](src/display/data-sch
 asset key/URL or an inline `AssetSource` descriptor. Use a descriptor when a
 URL-backed texture needs Pixi loader options such as SVG `resolution`.
 
+`background.source` also accepts a `TextureStyle` object such as
+`{ type: 'rect', fill: 'white' }`. Objects with a `src` field are treated as
+`AssetSource` descriptors and must match the descriptor schema.
+
 ```js
 const svgIcon = {
   type: 'icon',
@@ -257,6 +261,19 @@ const svgBackground = {
 
 `AssetSource` is for direct URLs or data URIs. Continue to use `init({ assets })`
 and string sources for reusable public aliases.
+
+Allowed `AssetSource` fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `src` | Yes | URL or data URI passed to Pixi `Assets.load`. |
+| `data` | No | Pixi loader data, for example `{ resolution: 3 }` for SVGs. |
+| `format` | No | File format hint passed through to Pixi. |
+| `parser` | No | Pixi asset parser id such as `'svg'` or `'texture'`. |
+| `loadParser` | No | Deprecated Pixi parser field accepted for compatibility. |
+
+Inline descriptors do not accept a public `alias`; PATCH MAP generates an
+internal cache key from `src`, `data`, `format`, and `parser`/`loadParser`.
 
 #### Spacing shorthand
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -242,6 +242,10 @@ draw method가 요구하는 **데이터 구조**입니다.
 또는 inline `AssetSource` descriptor를 사용할 수 있습니다. SVG `resolution`
 같은 Pixi loader 옵션이 필요한 URL 기반 texture에는 descriptor를 사용하세요.
 
+`background.source`는 `{ type: 'rect', fill: 'white' }` 같은 `TextureStyle`
+객체도 계속 허용합니다. `src` 필드가 있는 객체는 `AssetSource` descriptor로
+취급되며 descriptor schema를 만족해야 합니다.
+
 ```js
 const svgIcon = {
   type: 'icon',
@@ -264,6 +268,19 @@ const svgBackground = {
 
 `AssetSource`는 직접 URL 또는 data URI를 지정할 때 사용합니다. 재사용 가능한
 공개 alias는 계속 `init({ assets })`에 등록하고 문자열 source로 참조하세요.
+
+허용되는 `AssetSource` 필드는 다음과 같습니다.
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `src` | Yes | Pixi `Assets.load`에 전달할 URL 또는 data URI입니다. |
+| `data` | No | SVG의 `{ resolution: 3 }` 같은 Pixi loader data입니다. |
+| `format` | No | Pixi에 전달할 파일 format 힌트입니다. |
+| `parser` | No | `'svg'`, `'texture'` 같은 Pixi asset parser id입니다. |
+| `loadParser` | No | 호환성을 위해 허용하는 deprecated Pixi parser 필드입니다. |
+
+Inline descriptor에는 공개 `alias`를 지정할 수 없습니다. PATCH MAP은 `src`,
+`data`, `format`, `parser`/`loadParser`로 내부 cache key를 생성합니다.
 
 #### Spacing shorthand
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -236,6 +236,35 @@ patchmap.draw(data);
 draw method가 요구하는 **데이터 구조**입니다.  
 **자세한 타입 정의**는 [data.d.ts](src/display/data-schema/data.d.ts) 파일을 참조하세요.
 
+#### AssetSource descriptor
+
+`image.source`, `background.source`, `icon.source`에는 문자열 asset key/URL
+또는 inline `AssetSource` descriptor를 사용할 수 있습니다. SVG `resolution`
+같은 Pixi loader 옵션이 필요한 URL 기반 texture에는 descriptor를 사용하세요.
+
+```js
+const svgIcon = {
+  type: 'icon',
+  source: {
+    src: 'https://example.com/icon.svg',
+    data: { resolution: 3 },
+  },
+  tint: 'black',
+  size: 16,
+};
+
+const svgBackground = {
+  type: 'background',
+  source: {
+    src: 'https://example.com/background.svg',
+    data: { resolution: 3 },
+  },
+};
+```
+
+`AssetSource`는 직접 URL 또는 data URI를 지정할 때 사용합니다. 재사용 가능한
+공개 alias는 계속 `init({ assets })`에 등록하고 문자열 source로 참조하세요.
+
 #### Spacing shorthand
 
 컴포넌트의 `margin`, element/item의 `padding` 같은 박스형 spacing 필드는 `draw(data)`와 `update({ changes })` 모두에서 아래 입력을 정규화합니다.

--- a/src/assets/source.js
+++ b/src/assets/source.js
@@ -1,11 +1,10 @@
+import { isPlainObject } from 'is-plain-object';
+
 const ASSET_SOURCE_KEY_PREFIX = 'patchmap:asset-source:';
 const ASSET_SOURCE_FRAGMENT_PREFIX = 'patchmapAssetSource=';
 
-const isObject = (value) =>
-  value !== null && typeof value === 'object' && !Array.isArray(value);
-
 export const isAssetSource = (source) =>
-  isObject(source) && typeof source.src === 'string';
+  isPlainObject(source) && typeof source.src === 'string';
 
 const stableStringify = (value, seen = new WeakSet()) => {
   if (value === undefined) return '"__undefined__"';

--- a/src/assets/source.js
+++ b/src/assets/source.js
@@ -56,10 +56,21 @@ const inferParser = (src) => {
 };
 
 const cacheScopedSrc = (src, key) => {
-  const separator = src.includes('#') ? '&' : '#';
-  return `${src}${separator}${ASSET_SOURCE_FRAGMENT_PREFIX}${encodeURIComponent(
-    key,
-  )}`;
+  const cacheScope = `${ASSET_SOURCE_FRAGMENT_PREFIX}${encodeURIComponent(key)}`;
+  if (src.startsWith('data:')) {
+    const separator = src.includes('#') ? '&' : '#';
+    return `${src}${separator}${cacheScope}`;
+  }
+
+  const fragmentIndex = src.indexOf('#');
+  if (fragmentIndex === -1) {
+    return `${src}#${cacheScope}`;
+  }
+
+  const base = src.slice(0, fragmentIndex);
+  const fragment = src.slice(fragmentIndex);
+  const separator = base.includes('?') ? '&' : '?';
+  return `${base}${separator}${cacheScope}${fragment}`;
 };
 
 export const toLoadableAssetSource = (source) => {

--- a/src/assets/source.js
+++ b/src/assets/source.js
@@ -6,22 +6,31 @@ const ASSET_SOURCE_FRAGMENT_PREFIX = 'patchmapAssetSource=';
 export const isAssetSource = (source) =>
   isPlainObject(source) && typeof source.src === 'string';
 
-const stableStringify = (value, seen = new WeakSet()) => {
+const stableStringify = (value, ancestors = new WeakSet()) => {
   if (value === undefined) return '"__undefined__"';
   if (value === null || typeof value !== 'object') {
     return JSON.stringify(value);
   }
-  if (seen.has(value)) return '"__cycle__"';
-  seen.add(value);
+  if (ancestors.has(value)) return '"__cycle__"';
+  ancestors.add(value);
 
   if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item, seen)).join(',')}]`;
+    const result = `[${value
+      .map((item) => stableStringify(item, ancestors))
+      .join(',')}]`;
+    ancestors.delete(value);
+    return result;
   }
 
   const keys = Object.keys(value).sort();
-  return `{${keys
-    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key], seen)}`)
+  const result = `{${keys
+    .map(
+      (key) =>
+        `${JSON.stringify(key)}:${stableStringify(value[key], ancestors)}`,
+    )
     .join(',')}}`;
+  ancestors.delete(value);
+  return result;
 };
 
 export const assetSourceCacheKey = (source) =>

--- a/src/assets/source.js
+++ b/src/assets/source.js
@@ -1,0 +1,68 @@
+const ASSET_SOURCE_KEY_PREFIX = 'patchmap:asset-source:';
+const ASSET_SOURCE_FRAGMENT_PREFIX = 'patchmapAssetSource=';
+
+const isObject = (value) =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+export const isAssetSource = (source) =>
+  isObject(source) && typeof source.src === 'string';
+
+const stableStringify = (value, seen = new WeakSet()) => {
+  if (value === undefined) return '"__undefined__"';
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (seen.has(value)) return '"__cycle__"';
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item, seen)).join(',')}]`;
+  }
+
+  const keys = Object.keys(value).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key], seen)}`)
+    .join(',')}}`;
+};
+
+export const assetSourceCacheKey = (source) =>
+  `${ASSET_SOURCE_KEY_PREFIX}${stableStringify({
+    src: source.src,
+    data: source.data ?? {},
+    format: source.format,
+    parser: source.parser ?? source.loadParser,
+  })}`;
+
+const inferParser = (src) => {
+  const normalizedSrc = src.split('#')[0].split('?')[0].toLowerCase();
+  if (src.startsWith('data:image/svg+xml') || normalizedSrc.endsWith('.svg')) {
+    return 'svg';
+  }
+  if (
+    /^data:image\/(png|jpeg|jpg|webp|avif)/.test(src) ||
+    /\.(png|jpe?g|webp|avif)$/.test(normalizedSrc)
+  ) {
+    return 'texture';
+  }
+  return undefined;
+};
+
+const cacheScopedSrc = (src, key) => {
+  const separator = src.includes('#') ? '&' : '#';
+  return `${src}${separator}${ASSET_SOURCE_FRAGMENT_PREFIX}${encodeURIComponent(
+    key,
+  )}`;
+};
+
+export const toLoadableAssetSource = (source) => {
+  const key = assetSourceCacheKey(source);
+  const parser = source.parser ?? source.loadParser ?? inferParser(source.src);
+
+  return {
+    alias: key,
+    src: parser ? cacheScopedSrc(source.src, key) : source.src,
+    ...(source.data === undefined ? {} : { data: source.data }),
+    ...(source.format === undefined ? {} : { format: source.format }),
+    ...(parser === undefined ? {} : { parser }),
+  };
+};

--- a/src/assets/source.test.js
+++ b/src/assets/source.test.js
@@ -93,4 +93,17 @@ describe('asset source helpers', () => {
     expect(loadable.src.endsWith('#router')).toBe(true);
     expect(loadable.parser).toBe('svg');
   });
+
+  it('preserves existing query strings and fragments together', () => {
+    const loadable = toLoadableAssetSource({
+      src: 'https://example.com/icons.svg?token=abc#router',
+      data: { resolution: 3 },
+    });
+
+    expect(loadable.src).toContain(
+      'https://example.com/icons.svg?token=abc&patchmapAssetSource=',
+    );
+    expect(loadable.src.endsWith('#router')).toBe(true);
+    expect(loadable.parser).toBe('svg');
+  });
 });

--- a/src/assets/source.test.js
+++ b/src/assets/source.test.js
@@ -81,4 +81,16 @@ describe('asset source helpers', () => {
     expect(loadable.src).toContain('patchmapAssetSource=');
     expect(loadable.parser).toBe('svg');
   });
+
+  it('preserves existing URL fragments when scoping image loader URLs', () => {
+    const loadable = toLoadableAssetSource({
+      src: 'https://example.com/icons.svg#router',
+      data: { resolution: 3 },
+    });
+
+    expect(loadable.src).toContain('https://example.com/icons.svg?');
+    expect(loadable.src).toContain('patchmapAssetSource=');
+    expect(loadable.src.endsWith('#router')).toBe(true);
+    expect(loadable.parser).toBe('svg');
+  });
 });

--- a/src/assets/source.test.js
+++ b/src/assets/source.test.js
@@ -25,6 +25,23 @@ describe('asset source helpers', () => {
     expect(assetSourceCacheKey(left)).toBe(assetSourceCacheKey(right));
   });
 
+  it('does not treat reused data objects as cycles', () => {
+    const sharedOptions = { scaleMode: 'linear', mipmap: false };
+    const sharedObjectKey = assetSourceCacheKey({
+      src: 'icon.svg',
+      data: { left: sharedOptions, right: sharedOptions },
+    });
+    const duplicatedObjectKey = assetSourceCacheKey({
+      src: 'icon.svg',
+      data: {
+        left: { scaleMode: 'linear', mipmap: false },
+        right: { scaleMode: 'linear', mipmap: false },
+      },
+    });
+
+    expect(sharedObjectKey).toBe(duplicatedObjectKey);
+  });
+
   it('keeps descriptors with different loader options separated', () => {
     const source = { src: 'icon.svg', data: { resolution: 2 } };
     const higherResolution = { src: 'icon.svg', data: { resolution: 3 } };
@@ -41,13 +58,14 @@ describe('asset source helpers', () => {
   });
 
   it('uses an internal alias and never forwards caller-provided alias', () => {
-    const loadable = toLoadableAssetSource({
+    const source = {
       src: 'mock://icon',
       alias: 'public-alias',
       data: { resolution: 3 },
-    });
+    };
+    const loadable = toLoadableAssetSource(source);
 
-    expect(loadable.alias).toBe(assetSourceCacheKey(loadable));
+    expect(loadable.alias).toBe(assetSourceCacheKey(source));
     expect(loadable.alias).not.toBe('public-alias');
     expect(loadable.src).toBe('mock://icon');
     expect(loadable.data).toEqual({ resolution: 3 });

--- a/src/assets/source.test.js
+++ b/src/assets/source.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assetSourceCacheKey,
+  isAssetSource,
+  toLoadableAssetSource,
+} from './source';
+
+describe('asset source helpers', () => {
+  it('detects inline asset source descriptors', () => {
+    expect(isAssetSource({ src: 'icon.svg' })).toBe(true);
+    expect(isAssetSource({ type: 'rect', fill: 'white' })).toBe(false);
+    expect(isAssetSource('icon.svg')).toBe(false);
+  });
+
+  it('builds stable cache keys for equivalent descriptor data', () => {
+    const left = {
+      src: 'icon.svg',
+      data: { resolution: 3, options: { scaleMode: 'linear', mipmap: false } },
+    };
+    const right = {
+      data: { options: { mipmap: false, scaleMode: 'linear' }, resolution: 3 },
+      src: 'icon.svg',
+    };
+
+    expect(assetSourceCacheKey(left)).toBe(assetSourceCacheKey(right));
+  });
+
+  it('keeps descriptors with different loader options separated', () => {
+    const source = { src: 'icon.svg', data: { resolution: 2 } };
+    const higherResolution = { src: 'icon.svg', data: { resolution: 3 } };
+
+    expect(assetSourceCacheKey(source)).not.toBe(
+      assetSourceCacheKey(higherResolution),
+    );
+  });
+
+  it('normalizes parser and loadParser when building cache keys', () => {
+    expect(assetSourceCacheKey({ src: 'icon.svg', parser: 'svg' })).toBe(
+      assetSourceCacheKey({ src: 'icon.svg', loadParser: 'svg' }),
+    );
+  });
+
+  it('uses an internal alias and never forwards caller-provided alias', () => {
+    const loadable = toLoadableAssetSource({
+      src: 'mock://icon',
+      alias: 'public-alias',
+      data: { resolution: 3 },
+    });
+
+    expect(loadable.alias).toBe(assetSourceCacheKey(loadable));
+    expect(loadable.alias).not.toBe('public-alias');
+    expect(loadable.src).toBe('mock://icon');
+    expect(loadable.data).toEqual({ resolution: 3 });
+  });
+
+  it('scopes image loader URLs while preserving the original parser type', () => {
+    const loadable = toLoadableAssetSource({
+      src: 'https://example.com/icon.svg?token=abc',
+      data: { resolution: 3 },
+    });
+
+    expect(loadable.src).toContain('https://example.com/icon.svg?token=abc#');
+    expect(loadable.src).toContain('patchmapAssetSource=');
+    expect(loadable.parser).toBe('svg');
+  });
+});

--- a/src/display/data-schema/component-schema.js
+++ b/src/display/data-schema/component-schema.js
@@ -13,10 +13,9 @@ import {
 
 const TextureStyleSource = z
   .unknown()
-  .refine(
-    (source) => !(isPlainObject(source) && Object.hasOwn(source, 'src')),
-    { message: 'Asset source objects must match the AssetSource schema.' },
-  )
+  .refine((source) => !(isPlainObject(source) && 'src' in source), {
+    message: 'Asset source objects must match the AssetSource schema.',
+  })
   .pipe(TextureStyle);
 
 /**

--- a/src/display/data-schema/component-schema.js
+++ b/src/display/data-schema/component-schema.js
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  AssetSource,
   Base,
   Color,
   LabelTextStyle,
@@ -9,14 +10,28 @@ import {
   TextureStyle,
 } from './primitive-schema';
 
+const TextureStyleSource = z
+  .unknown()
+  .refine(
+    (source) =>
+      !(
+        source !== null &&
+        typeof source === 'object' &&
+        Object.hasOwn(source, 'src')
+      ),
+    { message: 'Asset source objects must match the AssetSource schema.' },
+  )
+  .pipe(TextureStyle);
+
 /**
- * An Item's background, sourced from a style object or an asset URL.
+ * An Item's background, sourced from a style object, asset key, URL, or
+ * AssetSource descriptor.
  * Visually represented by a `NineSliceSprite`.
  * @see {@link https://pixijs.download/release/docs/scene.NineSliceSprite.html}
  */
 export const backgroundSchema = Base.extend({
   type: z.literal('background'),
-  source: z.union([TextureStyle, z.string()]),
+  source: z.union([z.string(), AssetSource, TextureStyleSource]),
   size: z
     .any()
     .optional()
@@ -44,13 +59,14 @@ export const barSchema = Base.extend({
 }).strict();
 
 /**
- * A component for displaying an icon image.
+ * A component for displaying an icon image from an asset key, URL, or
+ * AssetSource descriptor.
  * Visually represented by a `Sprite`.
  * @see {@link https://pixijs.download/release/docs/scene.Sprite.html}
  */
 export const iconSchema = Base.extend({
   type: z.literal('icon'),
-  source: z.string(),
+  source: z.union([z.string(), AssetSource]),
   size: PxOrPercentSize,
   placement: Placement.default('center'),
   margin: Margin.default(0),

--- a/src/display/data-schema/component-schema.js
+++ b/src/display/data-schema/component-schema.js
@@ -1,3 +1,4 @@
+import { isPlainObject } from 'is-plain-object';
 import { z } from 'zod';
 import {
   AssetSource,
@@ -13,12 +14,7 @@ import {
 const TextureStyleSource = z
   .unknown()
   .refine(
-    (source) =>
-      !(
-        source !== null &&
-        typeof source === 'object' &&
-        Object.hasOwn(source, 'src')
-      ),
+    (source) => !(isPlainObject(source) && Object.hasOwn(source, 'src')),
     { message: 'Asset source objects must match the AssetSource schema.' },
   )
   .pipe(TextureStyle);

--- a/src/display/data-schema/component-schema.test.js
+++ b/src/display/data-schema/component-schema.test.js
@@ -37,6 +37,29 @@ describe('Component Schemas', () => {
       expect(parsed.source).toEqual({ type: 'rect', fill: 'red' });
     });
 
+    it('should parse with an AssetSource object source', () => {
+      const data = {
+        type: 'background',
+        source: {
+          src: 'https://example.com/background.svg',
+          data: { resolution: 3 },
+        },
+      };
+      const parsed = backgroundSchema.parse(data);
+      expect(parsed.source).toEqual(data.source);
+    });
+
+    it('should reject invalid AssetSource objects instead of parsing them as TextureStyle', () => {
+      const data = {
+        type: 'background',
+        source: {
+          src: 'https://example.com/background.svg',
+          alias: 'not-allowed-inline',
+        },
+      };
+      expect(() => backgroundSchema.parse(data)).toThrow();
+    });
+
     it('should fail with an invalid source type', () => {
       const data = { type: 'background', source: 123 };
       expect(() => backgroundSchema.parse(data)).toThrow();
@@ -192,6 +215,31 @@ describe('Component Schemas', () => {
       const dataWithoutSize = { type: 'icon', source: 'icon.svg' };
       expect(() => iconSchema.parse(dataWithoutSource)).toThrow();
       expect(() => iconSchema.parse(dataWithoutSize)).toThrow();
+    });
+
+    it('should parse an AssetSource object source', () => {
+      const data = {
+        type: 'icon',
+        source: {
+          src: 'https://example.com/icon.svg',
+          data: { resolution: 3 },
+        },
+        size: 50,
+      };
+      const parsed = iconSchema.parse(data);
+      expect(parsed.source).toEqual(data.source);
+    });
+
+    it('should reject inline icon asset aliases', () => {
+      const data = {
+        type: 'icon',
+        source: {
+          src: 'https://example.com/icon.svg',
+          alias: 'not-allowed-inline',
+        },
+        size: 50,
+      };
+      expect(() => iconSchema.parse(data)).toThrow();
     });
 
     it('should fail if size is a partial object', () => {

--- a/src/display/data-schema/data.d.ts
+++ b/src/display/data-schema/data.d.ts
@@ -556,12 +556,17 @@ export interface TextureStyle {
  * Use `init({ assets })` for reusable public aliases. Inline asset sources are
  * intended for direct URLs and receive an internal cache key derived from `src`
  * and loader options such as `data.resolution`.
+ *
+ * Inline descriptors are strict: public `alias` values are not accepted here.
+ * Objects with a `src` field in `background.source` are treated as AssetSource
+ * descriptors, not TextureStyle objects.
  */
 export interface AssetSource {
   /** URL or data URI passed to Pixi Assets.load. */
   src: string;
   /** Pixi loader data, for example `{ resolution: 3 }` for SVGs. */
   data?: Record<string, unknown>;
+  /** File format hint passed through to Pixi Assets.load. */
   format?: string;
   /** Pixi asset parser id, for example `'svg'` or `'texture'`. */
   parser?: string;

--- a/src/display/data-schema/data.d.ts
+++ b/src/display/data-schema/data.d.ts
@@ -200,8 +200,19 @@ export interface Relations {
 }
 
 /**
- * Renders an image from a URL or asset key as a standalone map element.
+ * Renders an image from an asset key, URL, or AssetSource descriptor as a
+ * standalone map element.
  * @see {@link https://pixijs.download/release/docs/scene.Sprite.html}
+ *
+ * @example
+ * const imageElementExample: ImageElement = {
+ *   type: 'image',
+ *   source: {
+ *     src: 'https://example.com/image.svg',
+ *     data: { resolution: 3 }
+ *   },
+ *   size: { width: 48, height: 48 }
+ * };
  */
 export interface ImageElement {
   type: 'image';
@@ -209,7 +220,7 @@ export interface ImageElement {
   label?: string;
   show?: boolean; // Default: true
   locked?: boolean; // Default: false
-  source: string;
+  source: string | AssetSource;
   size?: Size;
   attrs?: Record<string, unknown>;
 }
@@ -258,7 +269,8 @@ export interface RectElement {
 export type Component = Background | Bar | Icon | Text;
 
 /**
- * An Item's background, sourced from a style object or an asset URL.
+ * An Item's background, sourced from a style object, asset key, URL, or
+ * AssetSource descriptor.
  * @see {@link https://pixijs.download/release/docs/scene.NineSliceSprite.html}
  *
  * @example
@@ -276,13 +288,24 @@ export type Component = Background | Bar | Icon | Text;
  *   id: 'bg-image',
  *   source: 'background-image.png'
  * };
+ *
+ * @example
+ * // As an AssetSource descriptor with Pixi loader options
+ * const backgroundAssetSourceExample: Background = {
+ *   type: 'background',
+ *   id: 'bg-svg',
+ *   source: {
+ *     src: 'https://example.com/background.svg',
+ *     data: { resolution: 3 }
+ *   }
+ * };
  */
 export interface Background {
   type: 'background';
   id?: string; // Default: uid
   label?: string;
   show?: boolean; // Default: true
-  source: TextureStyle | string;
+  source: TextureStyle | string | AssetSource;
   tint?: Color;
   attrs?: Record<string, unknown>;
 }
@@ -318,7 +341,8 @@ export interface Bar {
 }
 
 /**
- * A component for displaying an icon image.
+ * A component for displaying an icon image from an asset key, URL, or
+ * AssetSource descriptor.
  * @see {@link https://pixijs.download/release/docs/scene.Sprite.html}
  *
  * @example
@@ -329,13 +353,23 @@ export interface Bar {
  *   size: 24, // 24px x 24px
  *   placement: 'left-top',
  * };
+ *
+ * @example
+ * const iconAssetSourceExample: Icon = {
+ *   type: 'icon',
+ *   source: {
+ *     src: 'https://example.com/warning.svg',
+ *     data: { resolution: 3 }
+ *   },
+ *   size: 24
+ * };
  */
 export interface Icon {
   type: 'icon';
   id?: string; // Default: uid
   label?: string;
   show?: boolean; // Default: true
-  source: string;
+  source: string | AssetSource;
   size: PxOrPercentSize;
   placement?: Placement; // Default: 'center'
   margin?: Margin; // Default: 0
@@ -515,6 +549,24 @@ export interface TextureStyle {
   borderWidth?: number; // Default: 0
   borderColor?: string; // Default: 'black'
   radius?: number | EachRadius; // Default: 0
+}
+
+/**
+ * Defines an inline Pixi asset source descriptor for URL-backed textures.
+ * Use `init({ assets })` for reusable public aliases. Inline asset sources are
+ * intended for direct URLs and receive an internal cache key derived from `src`
+ * and loader options such as `data.resolution`.
+ */
+export interface AssetSource {
+  /** URL or data URI passed to Pixi Assets.load. */
+  src: string;
+  /** Pixi loader data, for example `{ resolution: 3 }` for SVGs. */
+  data?: Record<string, unknown>;
+  format?: string;
+  /** Pixi asset parser id, for example `'svg'` or `'texture'`. */
+  parser?: string;
+  /** Deprecated Pixi parser field accepted for compatibility. */
+  loadParser?: string;
 }
 
 /**

--- a/src/display/data-schema/element-schema.js
+++ b/src/display/data-schema/element-schema.js
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { componentArraySchema } from './component-schema';
 import {
+  AssetSource,
   Base,
   Color,
   EachRadius,
@@ -89,7 +90,7 @@ export const relationsSchema = ElementBase.extend({
  */
 export const imageSchema = ElementBase.extend({
   type: z.literal('image'),
-  source: z.string(),
+  source: z.union([z.string(), AssetSource]),
   size: Size.optional(),
 }).strict();
 

--- a/src/display/data-schema/element-schema.test.js
+++ b/src/display/data-schema/element-schema.test.js
@@ -285,6 +285,31 @@ describe('Element Schemas', () => {
       expect(parsed.size).toEqual({ width: 100, height: 200 });
     });
 
+    it('should parse an image with an AssetSource object source', () => {
+      const imageData = {
+        type: 'image',
+        id: 'img-1',
+        source: {
+          src: 'https://example.com/image.svg',
+          data: { resolution: 3 },
+        },
+      };
+      const parsed = imageSchema.parse(imageData);
+      expect(parsed.source).toEqual(imageData.source);
+    });
+
+    it('should reject inline image asset aliases', () => {
+      const imageData = {
+        type: 'image',
+        id: 'img-1',
+        source: {
+          src: 'https://example.com/image.svg',
+          alias: 'not-allowed-inline',
+        },
+      };
+      expect(() => imageSchema.parse(imageData)).toThrow();
+    });
+
     it('should fail if source is missing', () => {
       const imageData = { type: 'image', id: 'img-1' };
       expect(() => imageSchema.parse(imageData)).toThrow();

--- a/src/display/data-schema/primitive-schema.js
+++ b/src/display/data-schema/primitive-schema.js
@@ -218,6 +218,16 @@ export const TextureStyle = z
   })
   .partial();
 
+export const AssetSource = z
+  .object({
+    src: z.string(),
+    data: z.record(z.string(), z.unknown()).optional(),
+    format: z.string().optional(),
+    parser: z.string().optional(),
+    loadParser: z.string().optional(),
+  })
+  .strict();
+
 /**
  * @see {@link https://pixijs.download/release/docs/scene.ConvertedStrokeStyle.html}
  */

--- a/src/display/mixins/Componentsizeable.js
+++ b/src/display/mixins/Componentsizeable.js
@@ -11,6 +11,25 @@ export const ComponentSizeable = (superClass) => {
       this.setSize(newSize.width, newSize.height);
       this.position.set(-newSize.borderWidth / 2);
     }
+
+    _onTextureApplied(texture) {
+      super._onTextureApplied?.(texture);
+
+      if (this.destroyed || this.props?.size === undefined) return;
+
+      this._applyComponentSize({
+        source: this.props.source,
+        size: this.props.size,
+        margin: this.props.margin,
+      });
+
+      if (typeof this._applyPlacement === 'function') {
+        this._applyPlacement({
+          placement: this.props.placement,
+          margin: this.props.margin,
+        });
+      }
+    }
   };
   MixedClass.registerHandler(
     KEYS,

--- a/src/display/mixins/ImageSizeable.js
+++ b/src/display/mixins/ImageSizeable.js
@@ -16,8 +16,8 @@ export const ImageSizeable = (superClass) => {
       this.store.viewport.emit('object_transformed', this);
     }
 
-    // Sourceable calls this after each texture application.
-    _onTextureApplied() {
+    _onTextureApplied(texture) {
+      super._onTextureApplied?.(texture);
       this._applyImageSize();
     }
   };

--- a/src/display/mixins/Sourceable.js
+++ b/src/display/mixins/Sourceable.js
@@ -1,4 +1,5 @@
 import { Assets, Texture } from 'pixi.js';
+import { isAssetSource, toLoadableAssetSource } from '../../assets/source';
 import { getTexture } from '../../assets/textures/texture';
 import { UPDATE_STAGES } from './constants';
 
@@ -18,6 +19,22 @@ export const Sourceable = (superClass) => {
 
       if (!source) {
         this._setTexture(Texture.EMPTY);
+        return;
+      }
+
+      if (isAssetSource(source)) {
+        Assets.load(toLoadableAssetSource(source))
+          .then((loadedTexture) => {
+            if (!this.destroyed && currentToken === this._loadToken) {
+              this._setTexture(loadedTexture);
+            }
+          })
+          .catch((err) => {
+            console.warn('[patchmap:source] failed to load', source, err);
+            if (!this.destroyed && currentToken === this._loadToken) {
+              this._setTexture(Texture.EMPTY);
+            }
+          });
         return;
       }
 

--- a/src/display/mixins/Sourceable.js
+++ b/src/display/mixins/Sourceable.js
@@ -23,19 +23,11 @@ export const Sourceable = (superClass) => {
       }
 
       if (isAssetSource(source)) {
-        this._setTexture(Texture.EMPTY);
-        Assets.load(toLoadableAssetSource(source))
-          .then((loadedTexture) => {
-            if (!this.destroyed && currentToken === this._loadToken) {
-              this._setTexture(loadedTexture);
-            }
-          })
-          .catch((err) => {
-            console.warn('[patchmap:source] failed to load', source, err);
-            if (!this.destroyed && currentToken === this._loadToken) {
-              this._setTexture(Texture.EMPTY);
-            }
-          });
+        this._loadSourceTexture(
+          source,
+          toLoadableAssetSource(source),
+          currentToken,
+        );
         return;
       }
 
@@ -56,8 +48,12 @@ export const Sourceable = (superClass) => {
         return;
       }
 
+      this._loadSourceTexture(source, source, currentToken);
+    }
+
+    _loadSourceTexture(source, loadableSource, currentToken) {
       this._setTexture(Texture.EMPTY);
-      Assets.load(source)
+      Assets.load(loadableSource)
         .then((loadedTexture) => {
           if (!this.destroyed && currentToken === this._loadToken) {
             this._setTexture(loadedTexture);

--- a/src/display/mixins/Sourceable.js
+++ b/src/display/mixins/Sourceable.js
@@ -23,6 +23,7 @@ export const Sourceable = (superClass) => {
       }
 
       if (isAssetSource(source)) {
+        this._setTexture(Texture.EMPTY);
         Assets.load(toLoadableAssetSource(source))
           .then((loadedTexture) => {
             if (!this.destroyed && currentToken === this._loadToken) {
@@ -55,6 +56,7 @@ export const Sourceable = (superClass) => {
         return;
       }
 
+      this._setTexture(Texture.EMPTY);
       Assets.load(source)
         .then((loadedTexture) => {
           if (!this.destroyed && currentToken === this._loadToken) {

--- a/src/tests/render/Image.test.js
+++ b/src/tests/render/Image.test.js
@@ -57,6 +57,73 @@ describe('Image Render', () => {
     expect(sizeSpy).not.toHaveBeenCalled();
   });
 
+  it('loads AssetSource descriptors with an internal alias', async () => {
+    const patchmap = getPatchmap();
+    const deferred = createDeferred();
+    const loadSpy = vi.spyOn(Assets, 'load').mockReturnValue(deferred.promise);
+
+    patchmap.draw([
+      {
+        type: 'image',
+        id: 'descriptor-image',
+        source: {
+          src: 'mock://descriptor-image',
+          data: { resolution: 3 },
+        },
+        size: { width: 48, height: 24 },
+        attrs: { x: 80, y: 80 },
+      },
+    ]);
+
+    expect(loadSpy).toHaveBeenCalledWith({
+      alias: expect.stringContaining('patchmap:asset-source:'),
+      src: 'mock://descriptor-image',
+      data: { resolution: 3 },
+    });
+
+    const image = patchmap.selector('$..[?(@.id=="descriptor-image")]')[0];
+    deferred.resolve(Texture.WHITE);
+    await flushPromises();
+
+    expect(image.props.source).toEqual({
+      src: 'mock://descriptor-image',
+      data: { resolution: 3 },
+    });
+    expect(image.sprite.texture).toBe(Texture.WHITE);
+  });
+
+  it('falls back to Texture.EMPTY when an AssetSource load fails', async () => {
+    const patchmap = getPatchmap();
+    const error = new Error('load failed');
+    vi.spyOn(Assets, 'load').mockRejectedValue(error);
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const source = { src: 'mock://missing-image', data: { resolution: 2 } };
+
+    patchmap.draw([
+      {
+        type: 'image',
+        id: 'missing-descriptor-image',
+        source,
+        size: { width: 48, height: 24 },
+        attrs: { x: 80, y: 80 },
+      },
+    ]);
+
+    const image = patchmap.selector(
+      '$..[?(@.id=="missing-descriptor-image")]',
+    )[0];
+
+    await vi.waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[patchmap:source] failed to load',
+        source,
+        error,
+      );
+    });
+
+    expect(image.sprite.texture).toBe(Texture.EMPTY);
+  });
+
   it('ignores late source loads after the image source is cleared', async () => {
     const patchmap = getPatchmap();
     const deferred = createDeferred();

--- a/src/tests/render/Image.test.js
+++ b/src/tests/render/Image.test.js
@@ -26,22 +26,25 @@ describe('Image Render', () => {
     vi.restoreAllMocks();
   });
 
+  const drawImage = (patchmap, overrides = {}) => {
+    const imageData = {
+      type: 'image',
+      id: 'slow-image',
+      source: 'mock://slow-image',
+      size: { width: 48, height: 24 },
+      attrs: { x: 80, y: 80 },
+      ...overrides,
+    };
+    patchmap.draw([imageData]);
+    return patchmap.selector(`$..[?(@.id=="${imageData.id}")]`)[0];
+  };
+
   it('ignores late source loads after the image is destroyed by redraw', async () => {
     const patchmap = getPatchmap();
     const deferred = createDeferred();
     const loadSpy = vi.spyOn(Assets, 'load').mockReturnValue(deferred.promise);
 
-    patchmap.draw([
-      {
-        type: 'image',
-        id: 'slow-image',
-        source: 'mock://slow-image',
-        size: { width: 48, height: 24 },
-        attrs: { x: 80, y: 80 },
-      },
-    ]);
-
-    const image = patchmap.selector('$..[?(@.id=="slow-image")]')[0];
+    const image = drawImage(patchmap);
     const setTextureSpy = vi.spyOn(image, '_setTexture');
     const sizeSpy = vi.spyOn(image, '_applyImageSize');
 
@@ -62,18 +65,13 @@ describe('Image Render', () => {
     const deferred = createDeferred();
     const loadSpy = vi.spyOn(Assets, 'load').mockReturnValue(deferred.promise);
 
-    patchmap.draw([
-      {
-        type: 'image',
-        id: 'descriptor-image',
-        source: {
-          src: 'mock://descriptor-image',
-          data: { resolution: 3 },
-        },
-        size: { width: 48, height: 24 },
-        attrs: { x: 80, y: 80 },
+    const image = drawImage(patchmap, {
+      id: 'descriptor-image',
+      source: {
+        src: 'mock://descriptor-image',
+        data: { resolution: 3 },
       },
-    ]);
+    });
 
     expect(loadSpy).toHaveBeenCalledWith({
       alias: expect.stringContaining('patchmap:asset-source:'),
@@ -81,7 +79,6 @@ describe('Image Render', () => {
       data: { resolution: 3 },
     });
 
-    const image = patchmap.selector('$..[?(@.id=="descriptor-image")]')[0];
     deferred.resolve(Texture.WHITE);
     await flushPromises();
 
@@ -99,19 +96,10 @@ describe('Image Render', () => {
     const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const source = { src: 'mock://missing-image', data: { resolution: 2 } };
 
-    patchmap.draw([
-      {
-        type: 'image',
-        id: 'missing-descriptor-image',
-        source,
-        size: { width: 48, height: 24 },
-        attrs: { x: 80, y: 80 },
-      },
-    ]);
-
-    const image = patchmap.selector(
-      '$..[?(@.id=="missing-descriptor-image")]',
-    )[0];
+    const image = drawImage(patchmap, {
+      id: 'missing-descriptor-image',
+      source,
+    });
 
     await vi.waitFor(() => {
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -129,17 +117,7 @@ describe('Image Render', () => {
     const deferred = createDeferred();
     const loadSpy = vi.spyOn(Assets, 'load').mockReturnValue(deferred.promise);
 
-    patchmap.draw([
-      {
-        type: 'image',
-        id: 'slow-image',
-        source: 'mock://slow-image',
-        size: { width: 48, height: 24 },
-        attrs: { x: 80, y: 80 },
-      },
-    ]);
-
-    const image = patchmap.selector('$..[?(@.id=="slow-image")]')[0];
+    const image = drawImage(patchmap);
 
     patchmap.update({
       path: '$..[?(@.id=="slow-image")]',

--- a/src/tests/render/components/Background.test.js
+++ b/src/tests/render/components/Background.test.js
@@ -1,4 +1,4 @@
-import { Sprite } from 'pixi.js';
+import { Sprite, Texture } from 'pixi.js';
 import { describe, expect, it, vi } from 'vitest';
 import { Base } from '../../../display/mixins/Base';
 import { Sourceable } from '../../../display/mixins/Sourceable';
@@ -64,6 +64,7 @@ describe('Background Component In Item', () => {
     const background = patchmap.selector(
       '$..[?(@.id=="asset-source-background")]',
     )[0];
+    expect(background.texture).toBe(Texture.EMPTY);
 
     await vi.waitFor(() => {
       expect(background.texture.source.resource.width).toBe(216);

--- a/src/tests/render/components/Background.test.js
+++ b/src/tests/render/components/Background.test.js
@@ -43,7 +43,7 @@ describe('Background Component In Item', () => {
   it('should render an AssetSource SVG background at the requested size', async () => {
     const patchmap = getPatchmap();
     const svgSource = `data:image/svg+xml,${encodeURIComponent(
-      '<svg width="72" height="36" viewBox="0 0 72 36" xmlns="http://www.w3.org/2000/svg"><rect width="72" height="36" fill="white"/></svg>',
+      '<svg width="76" height="38" viewBox="0 0 76 38" xmlns="http://www.w3.org/2000/svg"><rect width="76" height="38" fill="white"/></svg>',
     )}`;
 
     patchmap.draw([
@@ -67,7 +67,7 @@ describe('Background Component In Item', () => {
     expect(background.texture).toBe(Texture.EMPTY);
 
     await vi.waitFor(() => {
-      expect(background.texture.source.resource.width).toBe(216);
+      expect(background.texture.source.resource.width).toBe(228);
     });
 
     expect(background.props.source).toEqual({

--- a/src/tests/render/components/Background.test.js
+++ b/src/tests/render/components/Background.test.js
@@ -40,6 +40,43 @@ describe('Background Component In Item', () => {
     expect(background.tint).toBe(0xd9d9d9);
   });
 
+  it('should render an AssetSource SVG background at the requested size', async () => {
+    const patchmap = getPatchmap();
+    const svgSource = `data:image/svg+xml,${encodeURIComponent(
+      '<svg width="72" height="36" viewBox="0 0 72 36" xmlns="http://www.w3.org/2000/svg"><rect width="72" height="36" fill="white"/></svg>',
+    )}`;
+
+    patchmap.draw([
+      {
+        type: 'item',
+        id: 'item-with-asset-source-background',
+        size: { width: 100, height: 100 },
+        components: [
+          {
+            type: 'background',
+            id: 'asset-source-background',
+            source: { src: svgSource, data: { resolution: 3 } },
+          },
+        ],
+      },
+    ]);
+
+    const background = patchmap.selector(
+      '$..[?(@.id=="asset-source-background")]',
+    )[0];
+
+    await vi.waitFor(() => {
+      expect(background.texture.source.resource.width).toBe(216);
+    });
+
+    expect(background.props.source).toEqual({
+      src: svgSource,
+      data: { resolution: 3 },
+    });
+    expect(background.width).toBeCloseTo(100);
+    expect(background.height).toBeCloseTo(100);
+  });
+
   it('should update a single property: tint', () => {
     const patchmap = getPatchmap();
     patchmap.draw([baseItemData]);

--- a/src/tests/render/components/Icon.test.js
+++ b/src/tests/render/components/Icon.test.js
@@ -67,6 +67,39 @@ describe('Icon Component Tests', () => {
     expect(newTexture).not.toBe(initialTexture);
   });
 
+  it('should update the icon source between string and AssetSource values', async () => {
+    const patchmap = getPatchmap();
+    const svgSource = `data:image/svg+xml,${encodeURIComponent(
+      '<svg width="64" height="32" viewBox="0 0 64 32" xmlns="http://www.w3.org/2000/svg"><rect width="64" height="32" fill="white"/></svg>',
+    )}`;
+    const descriptor = { src: svgSource, data: { resolution: 2 } };
+
+    patchmap.draw([itemWithIcon]);
+
+    patchmap.update({
+      path: '$..[?(@.id=="icon-1")]',
+      changes: { source: descriptor },
+    });
+
+    const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
+
+    await vi.waitFor(() => {
+      expect(icon.texture.source.resource.width).toBe(128);
+    });
+
+    expect(icon.props.source).toEqual(descriptor);
+    expect(icon.width).toBeCloseTo(50);
+    expect(icon.height).toBeCloseTo(50);
+
+    patchmap.update({
+      path: '$..[?(@.id=="icon-1")]',
+      changes: { source: 'wifi' },
+    });
+
+    expect(icon.props.source).toBe('wifi');
+    expect(icon.texture.source.resource.width).not.toBe(128);
+  });
+
   it('should handle an unregistered string source by logging a warning', () => {
     const patchmap = getPatchmap();
     patchmap.draw([itemWithIcon]);
@@ -86,6 +119,80 @@ describe('Icon Component Tests', () => {
   });
 
   describe('size', () => {
+    it('should preserve requested size after an async SVG source loads', async () => {
+      const patchmap = getPatchmap();
+      const svgSource = `data:image/svg+xml,${encodeURIComponent(
+        '<svg width="72" height="36" viewBox="0 0 72 36" xmlns="http://www.w3.org/2000/svg"><rect width="72" height="36" fill="white"/></svg>',
+      )}`;
+
+      patchmap.draw([
+        {
+          type: 'item',
+          id: 'item-with-async-svg-icon',
+          size: 100,
+          components: [
+            {
+              type: 'icon',
+              id: 'async-svg-icon',
+              source: svgSource,
+              size: 24,
+              placement: 'center',
+            },
+          ],
+        },
+      ]);
+
+      const icon = patchmap.selector('$..[?(@.id=="async-svg-icon")]')[0];
+
+      await vi.waitFor(() => {
+        expect(icon.texture.source.resource.width).toBe(72);
+      });
+
+      expect(icon.width).toBeCloseTo(24);
+      expect(icon.height).toBeCloseTo(24);
+      expect(icon.x).toBeCloseTo(38);
+      expect(icon.y).toBeCloseTo(38);
+    });
+
+    it('should preserve requested size after an async AssetSource SVG loads', async () => {
+      const patchmap = getPatchmap();
+      const svgSource = `data:image/svg+xml,${encodeURIComponent(
+        '<svg width="80" height="40" viewBox="0 0 80 40" xmlns="http://www.w3.org/2000/svg"><rect width="80" height="40" fill="white"/></svg>',
+      )}`;
+
+      patchmap.draw([
+        {
+          type: 'item',
+          id: 'item-with-asset-source-icon',
+          size: 100,
+          components: [
+            {
+              type: 'icon',
+              id: 'asset-source-icon',
+              source: { src: svgSource, data: { resolution: 3 } },
+              size: 24,
+              placement: 'center',
+            },
+          ],
+        },
+      ]);
+
+      const icon = patchmap.selector('$..[?(@.id=="asset-source-icon")]')[0];
+
+      await vi.waitFor(() => {
+        expect(icon.texture.source.resource.width).toBe(240);
+      });
+
+      expect(icon.props.source).toEqual({
+        src: svgSource,
+        data: { resolution: 3 },
+      });
+      expect(icon.width).toBeCloseTo(24);
+      expect(icon.height).toBeCloseTo(24);
+      expect(icon.x).toBeCloseTo(38);
+      expect(icon.y).toBeCloseTo(38);
+    });
+
     it('should preserve raw numeric size during trusted initial draw', () => {
       const patchmap = getPatchmap();
       patchmap.draw([itemWithIcon]);

--- a/src/tests/render/components/Icon.test.js
+++ b/src/tests/render/components/Icon.test.js
@@ -1,3 +1,4 @@
+import { Texture } from 'pixi.js';
 import { describe, expect, it, vi } from 'vitest';
 import { setupPatchmapTests } from '../patchmap.setup';
 
@@ -82,6 +83,7 @@ describe('Icon Component Tests', () => {
     });
 
     const icon = patchmap.selector('$..[?(@.id=="icon-1")]')[0];
+    expect(icon.texture).toBe(Texture.EMPTY);
 
     await vi.waitFor(() => {
       expect(icon.texture.source.resource.width).toBe(128);
@@ -143,6 +145,7 @@ describe('Icon Component Tests', () => {
       ]);
 
       const icon = patchmap.selector('$..[?(@.id=="async-svg-icon")]')[0];
+      expect(icon.texture).toBe(Texture.EMPTY);
 
       await vi.waitFor(() => {
         expect(icon.texture.source.resource.width).toBe(72);
@@ -178,6 +181,7 @@ describe('Icon Component Tests', () => {
       ]);
 
       const icon = patchmap.selector('$..[?(@.id=="asset-source-icon")]')[0];
+      expect(icon.texture).toBe(Texture.EMPTY);
 
       await vi.waitFor(() => {
         expect(icon.texture.source.resource.width).toBe(240);

--- a/src/tests/render/components/Icon.test.js
+++ b/src/tests/render/components/Icon.test.js
@@ -5,6 +5,13 @@ import { setupPatchmapTests } from '../patchmap.setup';
 describe('Icon Component Tests', () => {
   const { getPatchmap } = setupPatchmapTests();
 
+  const expectIconFrame = (icon, expected) => {
+    expect(icon.width).toBeCloseTo(expected.width);
+    expect(icon.height).toBeCloseTo(expected.height);
+    if (expected.x !== undefined) expect(icon.x).toBeCloseTo(expected.x);
+    if (expected.y !== undefined) expect(icon.y).toBeCloseTo(expected.y);
+  };
+
   const itemWithIcon = {
     type: 'item',
     id: 'item-with-icon',
@@ -90,8 +97,7 @@ describe('Icon Component Tests', () => {
     });
 
     expect(icon.props.source).toEqual(descriptor);
-    expect(icon.width).toBeCloseTo(50);
-    expect(icon.height).toBeCloseTo(50);
+    expectIconFrame(icon, { width: 50, height: 50 });
 
     patchmap.update({
       path: '$..[?(@.id=="icon-1")]',
@@ -151,10 +157,7 @@ describe('Icon Component Tests', () => {
         expect(icon.texture.source.resource.width).toBe(72);
       });
 
-      expect(icon.width).toBeCloseTo(24);
-      expect(icon.height).toBeCloseTo(24);
-      expect(icon.x).toBeCloseTo(38);
-      expect(icon.y).toBeCloseTo(38);
+      expectIconFrame(icon, { width: 24, height: 24, x: 38, y: 38 });
     });
 
     it('should preserve requested size after an async AssetSource SVG loads', async () => {
@@ -191,10 +194,7 @@ describe('Icon Component Tests', () => {
         src: svgSource,
         data: { resolution: 3 },
       });
-      expect(icon.width).toBeCloseTo(24);
-      expect(icon.height).toBeCloseTo(24);
-      expect(icon.x).toBeCloseTo(38);
-      expect(icon.y).toBeCloseTo(38);
+      expectIconFrame(icon, { width: 24, height: 24, x: 38, y: 38 });
     });
 
     it('should preserve raw numeric size during trusted initial draw', () => {


### PR DESCRIPTION
## Summary
- Add inline `AssetSource` descriptors for image, background, and icon sources.
- Support Pixi loader options such as `data.resolution` for URL-backed SVG/textures while preserving public asset aliases for `init({ assets })`.
- Clear async source placeholders to `Texture.EMPTY` to avoid flashing white rectangles before load completion.

## Changes
- Added schema/type support for `AssetSource` and runtime conversion to Pixi `Assets.load` descriptors.
- Scoped cache keys by `src` and loader options so the same URL can load at different resolutions without cache collisions.
- Added render/schema coverage and README documentation in English and Korean.

## Tests
- `npm run test:unit -- --run src/assets/source.test.js src/display/data-schema/component-schema.test.js src/display/data-schema/element-schema.test.js`
- `npm run test:headless -- --run src/tests/render/components/Icon.test.js src/tests/render/components/Background.test.js src/tests/render/Image.test.js`
- `npx biome check src/display/mixins/Sourceable.js src/tests/render/components/Icon.test.js src/tests/render/components/Background.test.js`
