### PR TITLE
fix: order aggregate bar layer above grids

### DIFF
--- a/src/display/renderers/AggregateBarLayer.js
+++ b/src/display/renderers/AggregateBarLayer.js
@@ -455,6 +455,11 @@ export const ensureAggregateBarLayer = (store, texture) => {
   return layer;
 };
 
+export const refreshAggregateBarLayerOrder = (store) => {
+  if (!store?.world || !store.aggregateBarLayers) return;
+  placeAggregateBarLayers(store.world, store.aggregateBarLayers);
+};
+
 export const ensureAggregateBarLayerForBar = (bar) => {
   const texture = getBarTexture(bar);
   return ensureAggregateBarLayer(bar?.store, texture);
@@ -524,23 +529,22 @@ const placeAggregateBarLayers = (world, layers) => {
   if (activeLayers.length === 0) {
     return;
   }
-  if (isAggregateBarLayerBlockPlaced(world, activeLayers)) return;
+  const placement = resolveAggregateBarLayerPlacement(world, activeLayers);
+  for (const layer of activeLayers) {
+    layer.zIndex = placement.zIndex;
+  }
+  if (isAggregateBarLayerBlockPlaced(world, activeLayers, placement)) return;
 
   for (const layer of activeLayers) {
     layer.parent?.removeChild(layer);
   }
 
-  const relationIndex = world.children.findIndex(
-    (child) => child.type === 'relations',
-  );
-  const insertIndex =
-    relationIndex === -1 ? world.children.length : relationIndex;
   for (let offset = 0; offset < activeLayers.length; offset += 1) {
-    world.addChildAt(activeLayers[offset], insertIndex + offset);
+    world.addChildAt(activeLayers[offset], placement.insertIndex + offset);
   }
 };
 
-const isAggregateBarLayerBlockPlaced = (world, activeLayers) => {
+const isAggregateBarLayerBlockPlaced = (world, activeLayers, placement) => {
   const layerSet = new Set(activeLayers);
   const firstIndex = world.children.indexOf(activeLayers[0]);
   if (firstIndex === -1) return false;
@@ -551,12 +555,101 @@ const isAggregateBarLayerBlockPlaced = (world, activeLayers) => {
     }
   }
 
-  const relationIndex = world.children.findIndex(
-    (child) => !layerSet.has(child) && child.type === 'relations',
-  );
-  return (
-    relationIndex === -1 || firstIndex + activeLayers.length <= relationIndex
-  );
+  const currentInsertIndex = world.children
+    .slice(0, firstIndex)
+    .filter((child) => !layerSet.has(child)).length;
+  return currentInsertIndex === placement.insertIndex;
+};
+
+const resolveAggregateBarLayerPlacement = (world, activeLayers) => {
+  const layerSet = new Set(activeLayers);
+  const children = world.children.filter((child) => !layerSet.has(child));
+  const gridDepth = resolveGridDepth(children);
+
+  if (!gridDepth) {
+    return {
+      zIndex: 0,
+      insertIndex: findFirstIndex(
+        children,
+        (child) => child.type === 'relations',
+      ),
+    };
+  }
+
+  const zIndex = resolveLayerZIndex(children, gridDepth);
+  const insertIndex =
+    zIndex === gridDepth.zIndex
+      ? gridDepth.lastIndex + 1
+      : findFirstIndex(
+          children,
+          (child) => getZIndex(child) >= zIndex && !containsGrid(child),
+        );
+
+  return { zIndex, insertIndex };
+};
+
+const resolveGridDepth = (children) => {
+  let zIndex = Number.NEGATIVE_INFINITY;
+  let lastIndex = -1;
+
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index];
+    if (!containsGrid(child)) continue;
+
+    const childZIndex = getZIndex(child);
+    if (childZIndex > zIndex) {
+      zIndex = childZIndex;
+      lastIndex = index;
+    } else if (childZIndex === zIndex) {
+      lastIndex = index;
+    }
+  }
+
+  return lastIndex === -1 ? null : { zIndex, lastIndex };
+};
+
+const resolveLayerZIndex = (children, gridDepth) => {
+  let nearestHigherZIndex = Number.POSITIVE_INFINITY;
+  let hasSameDepthNonGridAbove = false;
+
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index];
+    if (containsGrid(child)) continue;
+
+    const childZIndex = getZIndex(child);
+    if (childZIndex > gridDepth.zIndex) {
+      nearestHigherZIndex = Math.min(nearestHigherZIndex, childZIndex);
+    } else if (
+      childZIndex === gridDepth.zIndex &&
+      index > gridDepth.lastIndex
+    ) {
+      hasSameDepthNonGridAbove = true;
+    }
+  }
+
+  if (hasSameDepthNonGridAbove) return gridDepth.zIndex;
+  if (Number.isFinite(nearestHigherZIndex)) {
+    return (gridDepth.zIndex + nearestHigherZIndex) / 2;
+  }
+  return gridDepth.zIndex + 1;
+};
+
+const findFirstIndex = (children, predicate) => {
+  const index = children.findIndex(predicate);
+  return index === -1 ? children.length : index;
+};
+
+const containsGrid = (node) => {
+  if (node?.type === 'grid') return true;
+  for (const child of node?.children ?? []) {
+    if (containsGrid(child)) return true;
+  }
+  return false;
+};
+
+const getZIndex = (node) => {
+  const zIndex = Number(node?.zIndex ?? 0);
+  return Number.isFinite(zIndex) ? zIndex : 0;
 };
 
 const getBarTexture = (bar) => {

--- a/src/display/renderers/AggregateBarLayer.js
+++ b/src/display/renderers/AggregateBarLayer.js
@@ -564,7 +564,8 @@ const isAggregateBarLayerBlockPlaced = (world, activeLayers, placement) => {
 const resolveAggregateBarLayerPlacement = (world, activeLayers) => {
   const layerSet = new Set(activeLayers);
   const children = world.children.filter((child) => !layerSet.has(child));
-  const gridDepth = resolveGridDepth(children);
+  const gridCache = new WeakMap();
+  const gridDepth = resolveGridDepth(children, gridCache);
 
   if (!gridDepth) {
     return {
@@ -576,25 +577,26 @@ const resolveAggregateBarLayerPlacement = (world, activeLayers) => {
     };
   }
 
-  const zIndex = resolveLayerZIndex(children, gridDepth);
+  const zIndex = resolveLayerZIndex(children, gridDepth, gridCache);
   const insertIndex =
     zIndex === gridDepth.zIndex
       ? gridDepth.lastIndex + 1
       : findFirstIndex(
           children,
-          (child) => getZIndex(child) >= zIndex && !containsGrid(child),
+          (child) =>
+            getZIndex(child) >= zIndex && !containsGrid(child, gridCache),
         );
 
   return { zIndex, insertIndex };
 };
 
-const resolveGridDepth = (children) => {
+const resolveGridDepth = (children, gridCache) => {
   let zIndex = Number.NEGATIVE_INFINITY;
   let lastIndex = -1;
 
   for (let index = 0; index < children.length; index += 1) {
     const child = children[index];
-    if (!containsGrid(child)) continue;
+    if (!containsGrid(child, gridCache)) continue;
 
     const childZIndex = getZIndex(child);
     if (childZIndex > zIndex) {
@@ -608,13 +610,13 @@ const resolveGridDepth = (children) => {
   return lastIndex === -1 ? null : { zIndex, lastIndex };
 };
 
-const resolveLayerZIndex = (children, gridDepth) => {
+const resolveLayerZIndex = (children, gridDepth, gridCache) => {
   let nearestHigherZIndex = Number.POSITIVE_INFINITY;
   let hasSameDepthNonGridAbove = false;
 
   for (let index = 0; index < children.length; index += 1) {
     const child = children[index];
-    if (containsGrid(child)) continue;
+    if (containsGrid(child, gridCache)) continue;
 
     const childZIndex = getZIndex(child);
     if (childZIndex > gridDepth.zIndex) {
@@ -639,11 +641,23 @@ const findFirstIndex = (children, predicate) => {
   return index === -1 ? children.length : index;
 };
 
-const containsGrid = (node) => {
-  if (node?.type === 'grid') return true;
-  for (const child of node?.children ?? []) {
-    if (containsGrid(child)) return true;
+const containsGrid = (node, cache) => {
+  if (!node) return false;
+  if (cache.has(node)) return cache.get(node);
+
+  if (node.type === 'grid') {
+    cache.set(node, true);
+    return true;
   }
+
+  for (const child of node?.children ?? []) {
+    if (containsGrid(child, cache)) {
+      cache.set(node, true);
+      return true;
+    }
+  }
+
+  cache.set(node, false);
   return false;
 };
 

--- a/src/display/update.js
+++ b/src/display/update.js
@@ -3,6 +3,7 @@ import { convertArray } from '../utils/convert';
 import { selector } from '../utils/selector/selector';
 import { getCentroid, getObjectFrameWorldCorners } from '../utils/transform';
 import { uid } from '../utils/uuid';
+import { refreshAggregateBarLayerOrder } from './renderers/AggregateBarLayer';
 import {
   flushQueuedAggregateBarLayers,
   syncAggregateBarForItem,
@@ -93,6 +94,7 @@ export const update = (root, opts = {}) => {
     });
     syncAggregateBarForItem(element, { immediateAggregateBarSync: true });
   }
+  refreshAggregateBarLayerOrder(root?.store);
   return elements;
 };
 

--- a/src/patchmap.js
+++ b/src/patchmap.js
@@ -5,6 +5,7 @@ import { UndoRedoManager } from './command/UndoRedoManager';
 import './display/components/registry';
 import { draw } from './display/draw';
 import './display/elements/registry';
+import { refreshAggregateBarLayerOrder } from './display/renderers/AggregateBarLayer';
 import { flushQueuedItemComponentUpdates, update } from './display/update';
 import ViewTransform from './display/view-transform/ViewTransform';
 import World from './display/World';
@@ -139,6 +140,18 @@ class Patchmap extends WildcardEventEmitter {
     store.world = this._world;
     this.viewport.addChild(this._world);
     this._viewTransform.attach({ viewport: this.viewport, world: this._world });
+    this.undoRedoManager.on(
+      'history:executed',
+      this._refreshAggregateBarLayerOrder,
+    );
+    this.undoRedoManager.on(
+      'history:undone',
+      this._refreshAggregateBarLayerOrder,
+    );
+    this.undoRedoManager.on(
+      'history:redone',
+      this._refreshAggregateBarLayerOrder,
+    );
 
     await initAsset(assetsOptions);
     initCanvas(element, this.app);
@@ -292,6 +305,10 @@ class Patchmap extends WildcardEventEmitter {
         this.emit('patchmap:flipped', { ...flip, target: this }),
     });
   }
+
+  _refreshAggregateBarLayerOrder = () => {
+    refreshAggregateBarLayerOrder(this.world?.store);
+  };
 
   _createStoreContext() {
     return {

--- a/src/tests/render/components/Bar.test.js
+++ b/src/tests/render/components/Bar.test.js
@@ -111,6 +111,85 @@ describe('Bar Component Tests', () => {
     expect(bar.props.size.width).toEqual({ value: 75, unit: '%' });
   });
 
+  it('keeps the aggregate bar layer between grids and higher relations', () => {
+    const patchmap = getPatchmap();
+    patchmap.draw([
+      {
+        type: 'grid',
+        id: 'aggregate-grid',
+        cells: [[1]],
+        item: {
+          size: { width: 80, height: 80 },
+          components: [],
+        },
+        attrs: { zIndex: 10 },
+      },
+      {
+        type: 'item',
+        id: 'aggregate-grid-overlay-item',
+        size: { width: 80, height: 80 },
+        components: [
+          {
+            type: 'bar',
+            id: 'aggregate-grid-overlay-bar',
+            source: { type: 'rect', fill: 'blue', radius: 4 },
+            size: '100%',
+            animation: false,
+          },
+        ],
+      },
+      {
+        type: 'relations',
+        id: 'aggregate-relations',
+        links: [],
+        style: { width: 1 },
+        attrs: { zIndex: 20 },
+      },
+    ]);
+
+    const grid = patchmap.selector('$..[?(@.id=="aggregate-grid")]')[0];
+    const item = patchmap.selector(
+      '$..[?(@.id=="aggregate-grid-overlay-item")]',
+    )[0];
+
+    patchmap.update({
+      elements: item,
+      changes: {
+        components: [
+          {
+            type: 'bar',
+            id: 'aggregate-grid-overlay-bar',
+            size: { width: '75%', height: 24 },
+          },
+        ],
+      },
+      validateSchema: false,
+      emit: false,
+    });
+
+    const bar = patchmap.selector(
+      '$..[?(@.id=="aggregate-grid-overlay-bar")]',
+    )[0];
+    const layer = patchmap.world.store.aggregateBarLayer;
+    const relations = patchmap.selector(
+      '$..[?(@.id=="aggregate-relations")]',
+    )[0];
+
+    expect(bar._patchmapUseAggregateBar).toBe(true);
+    expect(bar.renderable).toBe(false);
+    expect(layer.zIndex).toBeGreaterThan(grid.zIndex);
+    expect(layer.zIndex).toBeLessThan(relations.zIndex);
+
+    patchmap.update({
+      elements: grid,
+      changes: { attrs: { zIndex: 18 } },
+      emit: false,
+    });
+
+    expect(layer.zIndex).toBeGreaterThan(grid.zIndex);
+    expect(layer.zIndex).toBeLessThan(relations.zIndex);
+  });
+
   it('keeps aggregate bar particles aligned for rotated upright bar-only item updates', () => {
     const patchmap = getPatchmap();
     patchmap.draw([

--- a/src/tests/render/components/Bar.test.js
+++ b/src/tests/render/components/Bar.test.js
@@ -183,9 +183,20 @@ describe('Bar Component Tests', () => {
     patchmap.update({
       elements: grid,
       changes: { attrs: { zIndex: 18 } },
+      history: true,
       emit: false,
     });
 
+    expect(layer.zIndex).toBeGreaterThan(grid.zIndex);
+    expect(layer.zIndex).toBeLessThan(relations.zIndex);
+
+    patchmap.undoRedoManager.undo();
+    expect(grid.zIndex).toBe(10);
+    expect(layer.zIndex).toBeGreaterThan(grid.zIndex);
+    expect(layer.zIndex).toBeLessThan(relations.zIndex);
+
+    patchmap.undoRedoManager.redo();
+    expect(grid.zIndex).toBe(18);
     expect(layer.zIndex).toBeGreaterThan(grid.zIndex);
     expect(layer.zIndex).toBeLessThan(relations.zIndex);
   });
@@ -522,6 +533,16 @@ describe('Bar Component Tests', () => {
     const patchmap = getPatchmap();
     patchmap.draw([
       {
+        type: 'grid',
+        id: 'aggregate-source-grid',
+        cells: [[1]],
+        item: {
+          size: { width: 80, height: 80 },
+          components: [],
+        },
+        attrs: { zIndex: 10 },
+      },
+      {
         type: 'item',
         id: 'aggregate-source-item-a',
         size: { width: 200, height: 100 },
@@ -549,9 +570,15 @@ describe('Bar Component Tests', () => {
           },
         ],
       },
-      { type: 'relations', id: 'aggregate-source-relations', links: [] },
+      {
+        type: 'relations',
+        id: 'aggregate-source-relations',
+        links: [],
+        attrs: { zIndex: 20 },
+      },
     ]);
 
+    const grid = patchmap.selector('$..[?(@.id=="aggregate-source-grid")]')[0];
     const items = [
       patchmap.selector('$..[?(@.id=="aggregate-source-item-a")]')[0],
       patchmap.selector('$..[?(@.id=="aggregate-source-item-b")]')[0],
@@ -580,9 +607,21 @@ describe('Bar Component Tests', () => {
     )[0];
     const relationIndex = patchmap.world.children.indexOf(relations);
     for (const layer of layers) {
+      expect(layer.zIndex).toBeGreaterThan(grid.zIndex);
+      expect(layer.zIndex).toBeLessThan(relations.zIndex);
       expect(patchmap.world.children.indexOf(layer)).toBeLessThan(
         relationIndex,
       );
+    }
+
+    patchmap.update({
+      elements: grid,
+      changes: { attrs: { zIndex: 18 } },
+      emit: false,
+    });
+    for (const layer of layers) {
+      expect(layer.zIndex).toBeGreaterThan(grid.zIndex);
+      expect(layer.zIndex).toBeLessThan(relations.zIndex);
     }
   });
 


### PR DESCRIPTION
## Summary
- Fixes aggregate bar layer ordering so aggregate bars render above grids without forcing them above higher relation/non-grid layers.
- Keeps aggregate bar layer ordering refreshed after grid/relation zIndex updates, including undo/redo history replay.

## Related Issue / Discussion
- Fixes #
- Refs #

## Reproduction (Before Fix)
- Steps:
  1. Create a grid at zIndex 10 and relations at zIndex 20.
  2. Activate aggregate bar rendering for an item bar.
  3. Update grid zIndex or undo/redo a grid zIndex change.
- Actual behavior:
  - Aggregate bar layers were anchored relative to relations and could end up below grids or stale after history replay.
- Expected behavior:
  - Aggregate bar layers stay above the highest grid layer while remaining below higher relation/non-grid layers.

## Root Cause
- Aggregate bar layers were inserted before relations with a fixed zIndex, so placement was tied to relation order instead of grid depth.
- zIndex recalculation ran through normal update paths but not through undo/redo replay.

## Fix Strategy
- Key fix approach:
  - Compute aggregate layer placement from the highest world child containing grids, choose a zIndex between grids and the nearest higher non-grid layer, and refresh placement after normal updates and history events.
- Why this fix is safe:
  - Preserves existing below-relations behavior when no grids are present and keeps texture-source aggregate layers as a contiguous block.

## Validation
- [ ] `npm run test:unit`
- [ ] `npm run build`
- [ ] `npm run test:headless` (if UI interaction changed)
- Before fix verification:
  - Review found undo/redo history replay bypassed aggregate order refresh, and single-layer-only test coverage missed multi-texture aggregate layers.
- After fix verification:
  - `npx biome check src/command/commands/update.js src/patchmap.js src/tests/render/components/Bar.test.js`
  - `npx vitest --browser=chromium --browser.headless src/tests/render/components/Bar.test.js`
  - `npm run test:unit -- --run src/display/renderers/itemComponentRenderer.test.js src/display/update.test.js src/tests/undo-redo/Update.test.js`
- Regression test added/updated:
  - Added grid/relation aggregate ordering checks, history undo/redo zIndex replay checks, and multi-texture aggregate layer ordering checks.

## Documentation
- [ ] `README.md` updated
- [ ] `README_KR.md` updated
- [x] No documentation update needed

## Release Impact
- [ ] none (internal only)
- [x] patch (backward-compatible bug fix)
- [ ] minor (behavioral addition while fixing)

## Risk / Side Effects
- Impacted area:
  - Aggregate bar ParticleContainer layer ordering and update/history replay refresh.
- Potential side effects:
  - Extra placement refresh after updates and undo/redo events.
- Mitigation:
  - Refresh is a no-op without aggregate layers and targeted browser/unit tests cover aggregate render paths.

## Remaining Gaps / Follow-up (Optional)
- Gaps:
  - Full `npm run test:unit`, `npm run build`, and full `npm run test:headless` were not run in this session.
- Follow-up tasks:
  - Run full build/headless suite before marking PR ready if required by release process.
